### PR TITLE
Migrate NameChildrenRefresherJob from suckerpunch to activejob

### DIFF
--- a/.nsl-test-configs/editor-config.rb
+++ b/.nsl-test-configs/editor-config.rb
@@ -12,6 +12,7 @@ Rails.configuration.profile_v2_aware = true
 Rails.configuration.unsaved_form_prompt_enabled = true
 Rails.configuration.site_wide_form_prompt_enabled = true
 Rails.configuration.multi_product_tabs_enabled = false
+Rails.configuration.rails_8_upgrade = false
 Rails.configuration.nsl_linker = "http://localhost:9090/"
 # Services
 Rails.configuration.services_clientside_root_url = "#{external_services_host}/"

--- a/app/jobs/name_children_refresher_active_job.rb
+++ b/app/jobs/name_children_refresher_active_job.rb
@@ -1,0 +1,15 @@
+# ActiveJob version to refresh names - Rails 8.0 compatible.
+class NameChildrenRefresherActiveJob < ApplicationJob
+  def perform(name_id)
+    names_refreshed = 0
+    npaths_refreshed = 0
+    Rails.logger.info("NameChildrenRefresherActiveJob - an ActiveJob.")
+    Rails.logger.info("May be asynchronous")
+    
+    # ActiveJob handles database connections automatically
+    name = Name.find(name_id)
+    names_refreshed = name.refresh_tree
+    npaths_refreshed = name.refresh_name_paths
+    names_refreshed
+  end
+end

--- a/app/views/admin/_index.html.erb
+++ b/app/views/admin/_index.html.erb
@@ -201,7 +201,7 @@
     <tr><td class="width-40-percent min-width-10em">unsaved_form_prompt_enabled</td><td> <%= Rails.configuration.try(:unsaved_form_prompt_enabled) || false %> </td></tr>
     <tr><td class="width-40-percent min-width-10em">site_wide_form_prompt_enabled</td><td> <%= Rails.configuration.try(:site_wide_form_prompt_enabled) || false %> </td></tr>
     <tr><td class="width-40-percent min-width-10em">multi_product_tabs_enabled</td><td> <%= Rails.configuration.try(:multi_product_tabs_enabled) || false %> </td></tr>
-
+    <tr><td class="width-40-percent min-width-10em">rails_8_upgrade</td><td> <%= Rails.configuration.try(:rails_8_upgrade) || false %> </td></tr>
     </table>
     <br> <br>
     <h5>Instance delete delay</h5>


### PR DESCRIPTION
## Description
In preparation for rails 8, suckerpunch has been deprecated

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How to Test
<!-- Provide instructions for testing this PR -->

### New Dependencies
- [ ] Any new packages/gems?

## Tests
- [ ] Unit tests
- [ ] Manual testing

## Related Issues
<!-- Link to related issues (if any) -->

## Pre-merge steps
- [ ] Bumped version
- [ ] Updated changelog (Please add an entry to the changelog for the current year)
