### PR TITLE
NSL-5564: Batch Loader: Copying concept into batch from Loader 1 tab should now use primary instances for synonym matches

### DIFF
--- a/app/models/concerns/loader/name/preferred_match.rb
+++ b/app/models/concerns/loader/name/preferred_match.rb
@@ -31,14 +31,10 @@ module Loader::Name::PreferredMatch
 
   # Watch out for rare but possible case of no primary instance
   def instance_id_for_non_misapplied_match(instance)
-    if instance.standalone?
-      primary_instance = instance.name.primary_instances&.first
-      if primary_instance.nil?
-        raise NoPrimaryInstanceError.new
-      end
-      primary_instance.id
-    else
-      instance.id
+    primary_instance = instance.name.primary_instances&.first
+    if primary_instance.nil?
+      raise NoPrimaryInstanceError.new
     end
+    primary_instance.id
   end
 end

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 11-Sep-2025
+  :jira_id: '5564'
+  :description: |-
+    Batch Loader: Copying concept into batch from Loader 1 tab should now use primary instances for synonym matches
 - :date: 10-Sep-2025
   :jira_id: '5429'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.2.0.20
+appversion=4.2.0.21


### PR DESCRIPTION
## Description
Copying concept into batch from Loader 1 tab should now use primary instances for synonym matches

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
See Jira


## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
