### PR TITLE
NSL-5429: Tree permission fix

### DIFF
--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -435,7 +435,8 @@ class TreesController < ApplicationController
           .permit(:element_link,
                   :parent_element_link,
                   :update,
-                  :parent_name_typeahead_string)
+                  :parent_name_typeahead_string,
+                  :version_id)
   end
 
   def remove_name_placement_params

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -302,6 +302,9 @@ class Ability
     can :update_synonymy_by_instance, TreeVersion
     can :run_diff, TreeVersion
     can :run_valrep, TreeVersion
+    can :update_distribution, TreeVersion
+    can :update_comment, TreeVersion
+    can :update_tree_parent, TreeVersion
   end
 
   def admin_auth

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 10-Sep-2025
+  :jira_id: '5429'
+  :description: |-
+    Tree permissions: Add permissions for treebuilder user on Instance Tree tab actions so they work in the transition to product role permissions
 - :date: 11-Sep-2025
   :jira_id: '112'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.2.0.22
+appversion=4.2.0.23


### PR DESCRIPTION
## Description
NSL-5429: Tree permissions: Add permissions for treebuilder user on Instance Tree tab actions so they work in the transition to product role permissions

## Type of change
- [x] Bug fix for new code in Test

## How to Test
See the Jira


## Tests
- [ ] Unit tests
- [x] Manual testing


## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
