### PR TITLE
NSL-5429: Tree permissions fix

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -277,6 +277,7 @@ class Ability
     can "workspace_values",    :all
     can "trees/workspaces/current", "toggle"
     can "names/typeaheads/for_workspace_parent_name", :all
+    can :names_typeahead_for_workspace_parent, TreeVersion
     can "menu", "tree"
     can :edit, TreeVersion     # Added for transition to tree-publisher authorisations
     can :set_workspace, TreeVersion

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,4 +1,8 @@
-- :date: 10-Sep-2025
+- :date: 12-Sep-2025
+  :jira_id: '5429'
+  :description: |-
+    Tree permissions: Add permissions for treebuilder user to open parent typeahead - as before, for backwards compatibility during transition
+- :date: 12-Sep-2025
   :jira_id: '5429'
   :description: |-
     Tree permissions: Add permissions for treebuilder user on Instance Tree tab actions so they work in the transition to product role permissions

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.2.0.23
+appversion=4.2.0.24


### PR DESCRIPTION
## Description
NSL-5429:  Tree permissions: Add permissions for treebuilder user to open parent typeahead - as before, for backwards compatibility during transition

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue) for code in Test

## How to Test
See the Jira

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
