### PR TITLE
NSL-5429: Tree permissions: Refer to the user_product_role_v instead of separate tables in the ability.rb file to avoid N+1 queries

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -349,23 +349,22 @@ class Ability
   def tree_publisher_auth(session_user)
     can "menu", "tree"
     can "trees/workspaces/current", "toggle"
-    can :toggle_draft, Tree, products: { product_roles: { user_product_roles: { user_id:session_user.user_id} }}
+    can :toggle_draft, Tree, user_product_role_vs: { user_id:session_user.user_id }
     can 'tree_versions', 'edit_draft'
-    can :edit, Tree, products: { product_roles: { user_product_roles: { user_id:session_user.user_id} }}
-    can :edit, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :edit, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     can 'tree_versions', 'update_draft' # display the update_draft form
-    can :update_draft, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
-    can :update_draft, Tree::DraftVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :update_draft, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
+    can :update_draft, Tree::DraftVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     can 'tree_versions', 'form_to_publish' # display the publish draft form
     can 'tree_versions', 'publish' # call the action
-    can :publish, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :publish, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     can 'tree_versions', 'new_draft' # display the new draft form
     can 'tree_versions', 'create_draft' # display the new draft form
-    can :set_workspace, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
-    can :create_draft, Tree, products: { product_roles: { user_product_roles: { user_id:session_user.user_id} }}
+    can :set_workspace, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
+    can :create_draft, Tree, user_product_role_vs: { user_id:session_user.user_id }
     can "instances", "tab_classification"
 
     run_reports_on_a_draft_tree(session_user)
@@ -375,61 +374,63 @@ class Ability
   def tree_builder_auth(session_user)
     can "menu", "tree"
     can "trees/workspaces/current", "toggle"
-    can :toggle_draft, Tree, products: { product_roles: { user_product_roles: { user_id:session_user.user_id} }}
-    can :set_workspace, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :toggle_draft, Tree, user_product_role_vs: { user_id:session_user.user_id }
+    can :set_workspace, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
+
     can "classification", "place"
     can "instances", "tab_classification"
     # Note: update_comment also handles what looks to the user like insert and delete comment
     can "trees", "update_comment"
-    can :update_comment, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :update_comment, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
+
     # Note: update_distribution also handles what looks to the user like insert and delete distribution
     can "trees", "update_distribution"
-    can :update_distribution, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :update_distribution, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     can "names/typeaheads/for_workspace_parent_name", :all
-    can :names_typeahead_for_workspace_parent, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :names_typeahead_for_workspace_parent, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     can "trees", "update_tree_parent"
-    can :update_tree_parent, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :update_tree_parent, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     can "trees", "update_excluded"
-    can :update_excluded, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :update_excluded, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     can "trees", "replace_placement"
-    can :replace_placement, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :replace_placement, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     can "trees", "remove_name_placement"
-    can :remove_name_placement, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :remove_name_placement, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     can "trees", "place_name"
-    can :place_name, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :place_name, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     run_reports_on_a_draft_tree(session_user)
   end
 
   def run_reports_on_a_draft_tree(session_user)
     can "trees", "reports"
-    can :reports, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :reports, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     can "trees", "show_cas"
-    can :show_cas, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :show_cas, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     can "trees", "run_cas"
-    can :run_cas, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :run_cas, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     can "trees", "show_diff"
-    can :show_diff, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :show_diff, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     can "trees", "run_diff"
-    can :run_diff, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :run_diff, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     can "trees", "show_valrep"
-    can :show_valrep, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :show_valrep, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     can "trees", "run_valrep"
-    can :run_valrep, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :run_valrep, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
 
     can "trees", "update_synonymy_by_instance"
-    can :update_synonymy_by_instance, TreeVersion, tree: {products: { product_roles: { user_product_roles: { user_id:session_user.user_id}}}}
+    can :update_synonymy_by_instance, TreeVersion, tree: {user_product_role_vs: { user_id:session_user.user_id }}
   end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -48,6 +48,7 @@ class Product < ApplicationRecord
   has_many :profile_items, through: :product_item_configs, class_name: 'Profiles::ProfileItem'
   has_many :product_roles, class_name: "Product::Role"
   has_many :user_product_roles, class_name: "User::ProductRole", through: :product_roles
+  has_many :user_product_role_vs
 
   validates :name, presence: true
 

--- a/app/models/product/role.rb
+++ b/app/models/product/role.rb
@@ -46,6 +46,7 @@ class Product::Role < ActiveRecord::Base
   belongs_to :role, class_name: "::Role"
   belongs_to :product
   has_many :user_product_roles, class_name: "User::ProductRole", foreign_key: :product_role_id
+  has_many :user_product_role_vs
 
   def name
     "#{product.name} #{role.name} product role"

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -24,4 +24,5 @@ class Role < ActiveRecord::Base
   self.sequence_name = "nsl_global_seq"
   has_many :product_roles, class_name: "Product::Role"
   has_many :user_product_roles, class_name: "User::ProductRole", through: :product_roles
+  has_many :user_product_role_vs
 end

--- a/app/models/tree.rb
+++ b/app/models/tree.rb
@@ -63,6 +63,8 @@ class Tree < ActiveRecord::Base
 
   has_many :products
 
+  has_many :user_product_role_vs
+
   scope :accepted,
         (lambda do
           where(name: ShardConfig.classification_tree_key)

--- a/app/models/tree_version.rb
+++ b/app/models/tree_version.rb
@@ -49,6 +49,10 @@ class TreeVersion < ActiveRecord::Base
            foreign_key: "tree_version_id",
            class_name: "TreeVersionElement"
 
+  has_many :user_product_role_vs,
+           through: :tree
+
+
   before_save :stop_if_read_only
 
   # Returns a TreeVersionElement for this TreeVersion which contains the name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -47,6 +47,7 @@ class User < ActiveRecord::Base
   has_many :product_roles, through: :user_product_roles
   has_many :products, through: :product_roles
   has_many :roles, through: :product_roles
+  has_many :user_product_role_vs
 
   before_create :set_audit_fields, :force_lower_case_user_name
   before_update :set_updated_by

--- a/app/models/user_product_role_v.rb
+++ b/app/models/user_product_role_v.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# == Schema Information
+#
+# Table name: user_product_role
+#
+#  created_by      :string(50)       not null
+#  lock_version    :bigint           default(0), not null
+#  updated_by      :string(50)       not null
+#  created_at      :timestamptz      not null
+#  updated_at      :timestamptz      not null
+#  product_role_id :bigint           not null
+#  user_id         :bigint           not null, primary key
+#
+# Foreign Keys
+#
+#  upr_product_role_fk  (product_role_id => product_role.id)
+#  upr_users_fk         (user_id => users.id)
+#
+class UserProductRoleV < ActiveRecord::Base
+  strip_attributes
+  self.table_name = "user_product_role_v"
+  belongs_to :user
+  belongs_to :product
+  belongs_to :role
+  belongs_to :tree
+  belongs_to :tree_version
+  belongs_to :product_role, class_name: "Product::Role"
+end

--- a/config/history/changes-2025.yml
+++ b/config/history/changes-2025.yml
@@ -1,3 +1,7 @@
+- :date: 24-Sep-2025
+  :jira_id: '5429'
+  :description: |-
+    Tree permissions: Refer to the user_product_role_v instead of separate tables in the ability.rb file to avoid N+1 queries
 - :date: 23-Sep-2025
   :jira_id: '115'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=4.3.0.4
+appversion=4.3.0.5

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -8176,7 +8176,8 @@ CREATE VIEW public.user_product_role_v AS
     (product.is_name_index)::text AS is_name_index,
     users.id AS user_id,
     product.id AS product_id,
-    roles.id AS role_id
+    roles.id AS role_id,
+    tree.id AS tree_id
    FROM ((((((public.user_product_role upr
      JOIN public.users ON ((upr.user_id = users.id)))
      JOIN public.product_role pr ON ((upr.product_role_id = pr.id)))

--- a/test/controllers/instances/tabs/authorisation/for_apc/show_detail_and_apc_tab_links_test.rb
+++ b/test/controllers/instances/tabs/authorisation/for_apc/show_detail_and_apc_tab_links_test.rb
@@ -24,6 +24,7 @@ class InstanceEditorShowDetailAPCTabsTest < ActionController::TestCase
   setup do
     @instance = instances(:britten_created_angophora_costata)
     @request.headers["Accept"] = "application/javascript"
+    @working_draft = TreeVersion.first
   end
 
   test "should show detail and APC tab links if editor requests details tab" do
@@ -33,6 +34,7 @@ class InstanceEditorShowDetailAPCTabsTest < ActionController::TestCase
                   "row-type" => "instance_as_part_of_concept_record" },
         session: { username: "fred",
                    user_full_name: "Fred Jones",
+                   draft: @working_draft,
                    groups: ["treebuilder"] })
     asserts
   end

--- a/test/integration/taxonomy/menu/tree_publisher/apc/user_has_taxonomy_menu_options_test.rb
+++ b/test/integration/taxonomy/menu/tree_publisher/apc/user_has_taxonomy_menu_options_test.rb
@@ -28,6 +28,7 @@ class TreePublisherApcTaxoMenuOptions < ActionController::TestCase
         params: {},
         session: { username: user.user_name,
                    user_full_name: user.full_name,
+                   draft: @working_draft,
                    groups: ["login"] })
     assert_response :success
     assert_select "a",


### PR DESCRIPTION
## Description
Gerda has brought my attention to the N+1 queries generated by many of my statements in the ability.rb file for this Jira.  Statements like this:

  ` can :toggle_draft, Tree, products: { product_roles: { user_product_roles: { user_id:session_user.user_id} }}`

which result in Rails working through queries on the product, product_roles, user_product_roles tables in turn - which, actually doesn’t take much time because each query is so fast, but is undesirable.

The Bullet gem, when activated, warns about these in the log. 

I started trying to eliminate these N+1 queries in the recommended way, using a Rails includes method, but found this approach very unwieldy.  First, because I had to modify code all over the place in controllers and even views rather than just telling CanCanCan what to do.  Second, because adding an includes method in one place, to satisfy the CanCanCan ability needs removed the Bullet warning about the N+1 query in one place, but sometimes resulted in a Bullet warning that I should remove that very includes method because it was unnecessary in another place.  This was resulting in logic changes spread out through the code, resulting in extra complexity.  It was a bit like whack-a-mole.

I then tried a different approach - using the database view user_product_role_v in my ability.rb statements.  That view joins the necessary tables together - a beautiful encapsulation - with the result CanCanCan grabs all it needs in one query - no N+1 queries without any changes to code elsewhere.

The integration tests run clean.  Ideally no tester/user should notice anything different!

## Type of change
- [x] Technical fix (non-breaking change which fixes an issue)

## How to Test
See the Jira.

### New Dependencies
Needs an upgrade to user_product_role_v to add the test_id column.

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
