### PR TITLE
FLOR-200 - Remove set_profile_item_to_replaced method and related tes…

### DIFF
--- a/app/services/profile_items/published/create_new_version_service.rb
+++ b/app/services/profile_items/published/create_new_version_service.rb
@@ -23,7 +23,6 @@ class ProfileItems::Published::CreateNewVersionService < BaseService
       copy_profile_text
       copy_profile_item_annotation
       copy_profile_item_references
-      set_profile_item_to_replaced
       raise ActiveRecord::Rollback if errors.any?
     end
   end
@@ -35,13 +34,6 @@ class ProfileItems::Published::CreateNewVersionService < BaseService
   def published_profile_item
     return unless profile_item.is_draft
     errors.add(:base, "Profile item must be published before creating a new version")
-  end
-
-  def set_profile_item_to_replaced
-    profile_item.end_date = Time.current
-    profile_item.save
-
-    errors.merge!(profile_item.errors) if profile_item.errors.any?
   end
 
   def any_draft_profile_items

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,8 @@
+- :date: 10-Apr-2026
+  :jira_id: '200'
+  :jira_project: FLOR
+  :description: |-
+    Fixup the issue whenn publish PI is incorrectly setting the end_date of related profile items
 - :date: 09-Apr-2026
   :jira_id: '200'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.1.2
+appversion=5.1.1.3

--- a/spec/services/profile_items/published/create_new_version_service_spec.rb
+++ b/spec/services/profile_items/published/create_new_version_service_spec.rb
@@ -45,16 +45,6 @@ RSpec.describe ProfileItems::Published::CreateNewVersionService, type: :service 
         expect(new_draft.source_id_string).to be_nil
       end
 
-      it "marks the original profile item as replaced by setting its end_date" do
-        expect(profile_item.end_date).to be_nil
-
-        freeze_time do
-          subject.execute
-          profile_item.reload
-          expect(profile_item.end_date).to eq(Time.current)
-        end
-      end
-
       it "sets the correct attribues of the new profile text" do
         subject.execute
         new_draft = Profile::ProfileItem.where(is_draft: true).last


### PR DESCRIPTION
## Description
This pull request updates the logic for creating a new version of a published profile item by removing the step that marks the original profile item as replaced. The code no longer sets the `end_date` on the original item, and the related test has been removed.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
