### PR TITLE
Flor 200 create version end date setting

### DIFF
--- a/app/controllers/profile_items/publishes_controller.rb
+++ b/app/controllers/profile_items/publishes_controller.rb
@@ -1,7 +1,7 @@
 module ProfileItems
   class PublishesController < ProfileItemsController
 
-    before_action :set_profile_item
+    prepend_before_action :set_profile_item
     before_action :authorise_user!, only: [:create]
 
     def create

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,9 @@
 - :date: 10-Apr-2026
+  :jira_id: '200'
+  :jira_project: FLOR
+  :description: |-
+    Fix the profile_item not being set in the publish profile item controller by prepending the set_profile_item callback
+- :date: 10-Apr-2026
   :jira_id: '201'
   :jira_project: FLOR
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.1.5
+appversion=5.1.1.6

--- a/spec/controllers/profile_items/publishes_controller_spec.rb
+++ b/spec/controllers/profile_items/publishes_controller_spec.rb
@@ -11,7 +11,7 @@ describe ProfileItems::PublishesController, type: :controller do
   end
 
   describe 'POST #create' do
-    let(:profile_item) { create(:profile_item) }
+    let(:profile_item) { create(:profile_item, :draft) }
     let(:instance) { profile_item.instance }
     let(:service_errors) { ActiveModel::Errors.new("Some error") }
     let(:mock_service_result) { double("ProfileItems::Published::MarkPublishService", new_profile_item: profile_item, errors: {}) }
@@ -38,6 +38,41 @@ describe ProfileItems::PublishesController, type: :controller do
         expect(assigns(:product_configs_and_profile_items)).to eq([])
       end
 
+      context "when it has existing published profile item" do
+        let(:existing_published_profile_item) { create(:profile_item, end_date: nil, is_draft: false, instance: instance) }
+        let(:mock_product_and_product_item_config_result) { double("Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs", run_query: [[existing_published_profile_item], nil]) }
+
+        before do
+          allow(ProfileItems::Published::MarkPublishService).to receive(:call).and_return(mock_service_result)
+        end
+
+        it "calls the publish service" do
+          subject
+          expect(ProfileItems::Published::MarkPublishService).to have_received(:call).with(
+            user: current_user,
+            profile_item: profile_item,
+            params: hash_including(instance_id: instance.id.to_s, id: profile_item.id.to_s)
+          )
+        end
+      end
+
+      context "when it does not have existing published profile item" do
+        let(:mock_product_and_product_item_config_result) { double("Profile::ProfileItem::DefinedQuery::ProductAndProductItemConfigs", run_query: [[], nil]) }
+
+        before do
+          allow(ProfileItems::Published::MarkPublishService).to receive(:call).and_return(mock_service_result)
+        end
+
+        it "does not raise error" do
+          expect { subject }.not_to raise_error
+        end
+
+        it "does not mark any profile item as ended" do
+          expect(profile_item.end_date).to be_nil
+          subject
+          expect(profile_item.reload.end_date).to be_nil
+        end
+      end
     end
 
     context 'when publish fails' do


### PR DESCRIPTION
## Description
This pull request addresses a bug where the `profile_item` was not being set correctly in the `PublishesController` by adjusting the callback order. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
