### PR TITLE
Flor 200 create version end date setting

### DIFF
--- a/app/services/profile_items/published/mark_publish_service.rb
+++ b/app/services/profile_items/published/mark_publish_service.rb
@@ -38,7 +38,7 @@ class ProfileItems::Published::MarkPublishService < BaseService
   def previous_profile_item
     @previous_profile_item ||= Profile::ProfileItem
       .by_product_item_config(profile_item.product_item_config)
-      .where(is_draft: false)
+      .where(is_draft: false, instance_id: profile_item.instance_id)
       .where.not(id: profile_item.id)
       .order(published_date: :desc)
       .first

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,8 @@
+- :date: 14-Apr-2026
+  :jira_id: '200'
+  :jira_project: FLOR
+  :description: |-
+    Fixup incorrect end_date handling for related profile items in service object during publish.
 - :date: 13-Apr-2026
   :jira_id: '204'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.2.0
+appversion=5.1.2.1

--- a/spec/services/profile_items/published/mark_publish_service_spec.rb
+++ b/spec/services/profile_items/published/mark_publish_service_spec.rb
@@ -69,5 +69,63 @@ describe ProfileItems::Published::MarkPublishService do
         expect(profile_item.end_date).to be_nil
       end
     end
+
+    context 'when previous published items exist for a different instance' do
+      let!(:other_instance) { create(:instance, draft: false) }
+      let!(:other_instance_published) { create(:profile_item, :published, instance: other_instance, product_item_config:, published_date: 2.days.ago) }
+      let!(:profile_item) { create(:profile_item, :draft, created_by: "testuser", updated_by: "testuser", instance:, product_item_config:) }
+
+      it 'does not update the end_date of a profile item belonging to a different instance' do
+        expect { subject.execute }.not_to change { other_instance_published.reload.end_date }
+        expect(subject.errors).to be_empty
+      end
+    end
+
+    context 'when multiple previous published items exist for the same instance' do
+      let!(:older_published) { create(:profile_item, :published, instance:, product_item_config:, published_date: 5.days.ago) }
+      let!(:newer_published) { create(:profile_item, :published, instance:, product_item_config:, published_date: 2.days.ago) }
+      let!(:profile_item) { create(:profile_item, :draft, created_by: "testuser", updated_by: "testuser", instance:, product_item_config:) }
+
+      it 'updates end_date only on the most recently published item' do
+        subject.execute
+        expect(subject.errors).to be_empty
+        expect(newer_published.reload.end_date).to be_within(1.second).of(profile_item.reload.published_date)
+        expect { subject.execute }.not_to change { older_published.reload.end_date }
+      end
+    end
+
+    context 'when publish_profile_item fails' do
+      let!(:profile_item) { create(:profile_item, :draft, instance:, product_item_config:) }
+
+      before do
+        allow(profile_item).to receive(:save) do
+          profile_item.errors.add(:base, "Save failed")
+          false
+        end
+      end
+
+      it 'rolls back the transaction and returns errors' do
+        subject.execute
+        expect(subject.errors.full_messages).to include("Save failed")
+        expect(profile_item.reload.is_draft).to be_truthy
+      end
+    end
+
+    context 'when update_previous_profile_item fails' do
+      let!(:previous_published) { create(:profile_item, :published, instance:, product_item_config:, published_date: 2.days.ago) }
+      let!(:profile_item) { create(:profile_item, :draft, created_by: "testuser", updated_by: "testuser", instance:, product_item_config:) }
+
+      before do
+        allow_any_instance_of(Profile::ProfileItem).to receive(:update).and_wrap_original do |method, *args|
+          method.receiver.errors.add(:base, "Update failed")
+          false
+        end
+      end
+
+      it 'rolls back the transaction and returns errors' do
+        subject.execute
+        expect(subject.errors.full_messages).to include("Update failed")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description
This pull request addresses a bug in how related profile items are handled during publishing, specifically ensuring that only profile items from the same instance are considered when updating the `end_date` of previously published items. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
