### PR TITLE
NSL-5788 - Add duplicate badge styling to author name link text

### DIFF
--- a/app/assets/stylesheets/utilities/colors.css
+++ b/app/assets/stylesheets/utilities/colors.css
@@ -251,7 +251,8 @@ a:hover.blue           { color: blue; }
   font-weight: 500;
 }
 
-.badge.badge-muted-red {
+.badge.badge-muted-red,
+.badge.badge-duplicate {
   background: #FCEBEB;
   border: 0.5px solid #F09595;
   color: #791F1F;

--- a/app/views/application/search_results/link_texts/_author_name_link_text.html.erb
+++ b/app/views/application/search_results/link_texts/_author_name_link_text.html.erb
@@ -3,6 +3,9 @@
 <% else %>
   <%= "#{search_result.name}" %>
 <% end %>
-<% if search_result.duplicate? %> [Duplicate] <% end %>
-
-
+<% if search_result.duplicate? %>
+  <span
+    title="Record flagged as duplicate"
+    class="badge badge-duplicate"
+  >duplicate</span>
+<% end %>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 14-Apr-2026
+  :jira_id: '5788'
+  :description: |-
+    Duplicate badge css style for dubplicate author name in the searchr results
+- :date: 14-Apr-2026
   :jira_id: '200'
   :jira_project: FLOR
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.2.1
+appversion=5.1.2.2


### PR DESCRIPTION
## Description
This pull request improves the way duplicate records are indicated in search results by replacing the previous text-based "[Duplicate]" label with a styled badge. It also introduces a new CSS class for this badge to ensure consistent styling.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
