### PR TITLE
FLOR-204 - Fix nil check for manages_profile in tab_edit_profile cond…

### DIFF
--- a/app/views/instances/tabs/_all_tab_headings.html.erb
+++ b/app/views/instances/tabs/_all_tab_headings.html.erb
@@ -253,7 +253,7 @@
 
   <% if @tabs_to_offer.include?("tab_edit_profile") %>
     <% if Rails.configuration.try('profile_edit_aware') %>
-      <% if can?("tree/elements", "update_profile") || (!current_product_from_context.manages_profile && current_registered_user.role_names.include?("tree-builder"))%>
+      <% if can?("tree/elements", "update_profile") || (!current_product_from_context&.manages_profile && current_registered_user.role_names.include?("tree-builder"))%>
         <%= render(
           partial: "instances/tabs/tab",
           locals: {

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,8 @@
+- :date: 13-Apr-2026
+  :jira_id: '204'
+  :jira_project: FLOR
+  :description: |-
+    Fixup the undefined manages_profile for nil error in name instance search results when context is nil
 - :date: 10-Apr-2026
   :jira_id: '200'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.1.6
+appversion=5.1.1.7


### PR DESCRIPTION
## Description
This pull request makes a minor change to the way the `manages_profile` property is accessed in the `app/views/instances/tabs/_all_tab_headings.html.erb` file. The update uses safe navigation to prevent potential errors if `current_product_from_context` is `nil`. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
