### PR TITLE
FLOR-205 - Enable annotation creation on FOA instance and update tab …

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -20,6 +20,7 @@ class CommentsController < ApplicationController
   # All text/html requests should go to the search page.
   before_action :javascript_only
   before_action :set_comment, only: %i[show edit update destroy]
+  before_action :authorize_for_instance!, only: %i[create update destroy]
 
   # GET /comments/1
   # GET /comments/1.json
@@ -93,6 +94,25 @@ class CommentsController < ApplicationController
     else
       @message = "Not saved. #{@comment.errors.full_messages.first}"
       render :update_failed
+    end
+  end
+
+  def authorize_for_instance!
+    return unless Rails.configuration.try(:multi_product_tabs_enabled)
+
+    instance = find_instance_for_authorization
+    return unless instance
+
+    return if can?(:create_adnot, instance)
+
+    raise CanCan::AccessDenied.new("Access Denied!", :create_adnot, instance)
+  end
+
+  def find_instance_for_authorization
+    if @comment&.instance
+      @comment.instance
+    elsif comment_params[:instance_id].present?
+      Instance.find_by(id: comment_params[:instance_id])
     end
   end
 end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -111,7 +111,7 @@ class CommentsController < ApplicationController
   def find_instance_for_authorization
     if @comment&.instance
       @comment.instance
-    elsif comment_params[:instance_id].present?
+    elsif params[:comment].present? && comment_params[:instance_id].present?
       Instance.find_by(id: comment_params[:instance_id])
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -112,10 +112,14 @@ class Ability
         .joins(profile_item: :product_item_config)
         .where("product_item_configs_profile_item.product_id = ?", user.product_from_context&.id).any?)
     end
+    can :create_adnot, Instance do |instance|
+      instance.draft? && user.product_from_context&.has_the_same_reference?(instance)
+    end
     can "authors", :all
     can "instances", [
       "tab_details",
       "tab_profile_v2",
+      "tab_comments",
       "typeahead_for_product_item_config"
     ]
     can "menu", "new"
@@ -203,6 +207,7 @@ class Ability
 
   def profile_editor(session_user)
     user_products = session_user.user&.products || []
+    user_product_trees = user_products.map(&:tree).compact
 
     can :manage, :profile_v2
     can :manage, Profile::ProfileItem do |profile_item|
@@ -220,12 +225,16 @@ class Ability
     can :manage_profile, Instance do |instance|
       instance.profile_items.includes([:product]).any? { |item| item.product && user_products.include?(item.product) }
     end
+    can :create_adnot, Instance do |instance|
+      instance.in_local_trees.any? { |tree| user_product_trees.include?(tree) }
+    end
     can "references", "typeahead_on_citation"
     can "profile_items", :all
     can "profile_item_annotations", :all
     can "profile_item_references", :all
     can "instances", "tab_details"
     can "instances", "tab_profile_v2"
+    can "instances", "tab_comments"
   end
 
   def profile_v2_auth

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -112,6 +112,7 @@ class Ability
         .joins(profile_item: :product_item_config)
         .where("product_item_configs_profile_item.product_id = ?", user.product_from_context&.id).any?)
     end
+    can "comments", :all
     can :create_adnot, Instance do |instance|
       instance.draft? && user.product_from_context&.has_the_same_reference?(instance)
     end
@@ -225,6 +226,7 @@ class Ability
     can :manage_profile, Instance do |instance|
       instance.profile_items.includes([:product]).any? { |item| item.product && user_products.include?(item.product) }
     end
+    can "comments", :all
     can :create_adnot, Instance do |instance|
       instance.in_local_trees.any? { |tree| user_product_trees.include?(tree) }
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -208,7 +208,7 @@ class Ability
 
   def profile_editor(session_user)
     user_products = session_user.user&.products || []
-    user_product_trees = user_products.map(&:tree).compact
+    user_product_tree_ids = user_products.map(&:tree_id).compact
 
     can :manage, :profile_v2
     can :manage, Profile::ProfileItem do |profile_item|
@@ -227,7 +227,7 @@ class Ability
       instance.profile_items.includes([:product]).any? { |item| item.product && user_products.include?(item.product) }
     end
     can :create_adnot, Instance do |instance|
-      instance.in_local_trees.any? { |tree| user_product_trees.include?(tree) }
+      instance.in_any_local_tree_ids?(user_product_tree_ids)
     end
     can "comments", :all
     can "references", "typeahead_on_citation"

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -112,10 +112,10 @@ class Ability
         .joins(profile_item: :product_item_config)
         .where("product_item_configs_profile_item.product_id = ?", user.product_from_context&.id).any?)
     end
-    can "comments", :all
     can :create_adnot, Instance do |instance|
       instance.draft? && user.product_from_context&.has_the_same_reference?(instance)
     end
+    can "comments", :all
     can "authors", :all
     can "instances", [
       "tab_details",
@@ -226,10 +226,10 @@ class Ability
     can :manage_profile, Instance do |instance|
       instance.profile_items.includes([:product]).any? { |item| item.product && user_products.include?(item.product) }
     end
-    can "comments", :all
     can :create_adnot, Instance do |instance|
       instance.in_local_trees.any? { |tree| user_product_trees.include?(tree) }
     end
+    can "comments", :all
     can "references", "typeahead_on_citation"
     can "profile_items", :all
     can "profile_item_annotations", :all

--- a/app/models/concerns/instance_treeable.rb
+++ b/app/models/concerns/instance_treeable.rb
@@ -58,11 +58,11 @@ where te.instance_id = ?", id])
   def in_any_local_tree_ids?(tree_ids)
     return false if tree_ids.blank?
 
-    Tree.where(id: tree_ids)
-      .joins("JOIN tree_version_element tve ON tree.current_tree_version_id = tve.tree_version_id")
-      .joins("JOIN tree_element te ON tve.tree_element_id = te.id")
-      .where("te.instance_id = ?", id)
-      .exists?
+    Tree.joins("JOIN tree_version_element tve ON tree.current_tree_version_id = tve.tree_version_id")
+        .joins("JOIN tree_element te ON tve.tree_element_id = te.id")
+        .where(id: tree_ids)
+        .where("te.instance_id = ?", id)
+        .exists?
   end
 
   def in_local_tree_names

--- a/app/models/concerns/instance_treeable.rb
+++ b/app/models/concerns/instance_treeable.rb
@@ -55,6 +55,16 @@ module InstanceTreeable
 where te.instance_id = ?", id])
   end
 
+  def in_any_local_tree_ids?(tree_ids)
+    return false if tree_ids.blank?
+
+    Tree.where(id: tree_ids)
+      .joins("JOIN tree_version_element tve ON tree.current_tree_version_id = tve.tree_version_id")
+      .joins("JOIN tree_element te ON tve.tree_element_id = te.id")
+      .where("te.instance_id = ?", id)
+      .exists?
+  end
+
   def in_local_tree_names
     in_local_trees.collect do |tree|
       tree.name

--- a/app/views/instances/tabs/_all_tab_headings.html.erb
+++ b/app/views/instances/tabs/_all_tab_headings.html.erb
@@ -176,7 +176,7 @@
   <% end %>
 
   <% if @tabs_to_offer.include?("tab_comments") && tab_available?(tabs_array, "adnot") %>
-    <% if can?("comments", "create") %>
+    <% if can?("comments", "create") || can?(:create_adnot, @instance) %>
       <%= render(
         partial: "instances/tabs/tab",
         locals: {

--- a/app/views/instances/tabs/_all_tab_headings.html.erb
+++ b/app/views/instances/tabs/_all_tab_headings.html.erb
@@ -176,7 +176,7 @@
   <% end %>
 
   <% if @tabs_to_offer.include?("tab_comments") && tab_available?(tabs_array, "adnot") %>
-    <% if can?("comments", "create") || can?(:create_adnot, @instance) %>
+    <% if can?("comments", "create") || (can?(:create_adnot, @instance) && current_product_from_context&.has_the_same_reference?(@instance))%>
       <%= render(
         partial: "instances/tabs/tab",
         locals: {

--- a/app/views/instances/tabs/_all_tab_headings.html.erb
+++ b/app/views/instances/tabs/_all_tab_headings.html.erb
@@ -176,21 +176,23 @@
   <% end %>
 
   <% if @tabs_to_offer.include?("tab_comments") && tab_available?(tabs_array, "adnot") %>
-    <% if can?("comments", "create") || (can?(:create_adnot, @instance) && current_product_from_context&.has_the_same_reference?(@instance))%>
-      <%= render(
-        partial: "instances/tabs/tab",
-        locals: {
-          first: false,
-          last: true,
-          this_tab: "tab_comments",
-          link_text: product_tab_text(:instance, "adnot", "Adnot"),
-          link_id: "instance-comments-tab",
-          link_title: "Adnot",
-          tab_index: increment_tab_index,
-          prev_tab: "",
-          next_tab: ""
-        })
-      %>
+    <% if can?("comments", "create") %>
+      <% if !Rails.configuration.try('multi_product_tabs_enabled') || can?(:create_adnot, @instance) %>
+        <%= render(
+          partial: "instances/tabs/tab",
+          locals: {
+            first: false,
+            last: true,
+            this_tab: "tab_comments",
+            link_text: product_tab_text(:instance, "adnot", "Adnot"),
+            link_id: "instance-comments-tab",
+            link_title: "Adnot",
+            tab_index: increment_tab_index,
+            prev_tab: "",
+            next_tab: ""
+          })
+        %>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,8 @@
+- :date: 20-Apr-2026
+  :jira_id: '205'
+  :jira_project: FLOR
+  :description: |-
+    Apply adnot permissions for draft-profile-editor and profile-editor users
 - :date: 17-Apr-2026
   :jira_id: '2958'
   :description: |-

--- a/config/product_tabs/tabs.json
+++ b/config/product_tabs/tabs.json
@@ -61,7 +61,7 @@
       "tabs": ["details", "tree"]
     },
     "manages_profile": {
-      "tabs": ["details", "edit_profile", "syn_profile", "unpub_profile", "profile"]
+      "tabs": ["details", "edit_profile", "syn_profile", "unpub_profile", "profile", "adnot"]
     },
     "default": {
       "tabs": ["details"]

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.2.6
+appversion=5.1.2.7

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -966,7 +966,7 @@ RSpec.describe Ability, type: :model do
 
       context 'when instance is in a tree that user has access to' do
         before do
-          allow(instance).to receive(:in_local_trees).and_return([tree])
+          allow(instance).to receive(:in_any_local_tree_ids?).with([tree.id]).and_return(true)
         end
 
         it 'can create_adnot on the instance' do
@@ -975,10 +975,8 @@ RSpec.describe Ability, type: :model do
       end
 
       context 'when instance is in a tree that user does not have access to' do
-        let(:other_tree) { create(:tree) }
-
         before do
-          allow(instance).to receive(:in_local_trees).and_return([other_tree])
+          allow(instance).to receive(:in_any_local_tree_ids?).with([tree.id]).and_return(false)
         end
 
         it 'cannot create_adnot on the instance' do
@@ -988,7 +986,7 @@ RSpec.describe Ability, type: :model do
 
       context 'when instance is not in any local trees' do
         before do
-          allow(instance).to receive(:in_local_trees).and_return([])
+          allow(instance).to receive(:in_any_local_tree_ids?).with([tree.id]).and_return(false)
         end
 
         it 'cannot create_adnot on the instance' do
@@ -1003,7 +1001,7 @@ RSpec.describe Ability, type: :model do
           user.user_product_roles.destroy_all
           product_role = create(:product_role, product: product_without_tree)
           create(:user_product_role, user: user, product_role: product_role)
-          allow(instance).to receive(:in_local_trees).and_return([tree])
+          allow(instance).to receive(:in_any_local_tree_ids?).with([]).and_return(false)
         end
 
         it 'cannot create_adnot on the instance' do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -299,8 +299,62 @@ RSpec.describe Ability, type: :model do
       expect(subject.can?("instances", "typeahead_for_product_item_config")).to eq true
     end
 
+    it 'can access instances tab_comments' do
+      expect(subject.can?("instances", "tab_comments")).to eq true
+    end
+
     it 'can access menu new' do
       expect(subject.can?("menu", "new")).to eq true
+    end
+
+    it 'can access comments' do
+      expect(subject.can?("comments", :all)).to eq true
+    end
+
+    describe ':create_adnot permission' do
+      let(:instance) { create(:instance, draft: true) }
+
+      context 'when instance is draft and product has the same reference' do
+        before do
+          allow(product).to receive(:has_the_same_reference?).with(instance).and_return(true)
+        end
+
+        it 'can create_adnot on the instance' do
+          expect(subject.can?(:create_adnot, instance)).to eq true
+        end
+      end
+
+      context 'when instance is draft but product does not have the same reference' do
+        before do
+          allow(product).to receive(:has_the_same_reference?).with(instance).and_return(false)
+        end
+
+        it 'cannot create_adnot on the instance' do
+          expect(subject.can?(:create_adnot, instance)).to eq false
+        end
+      end
+
+      context 'when instance is not draft' do
+        let(:instance) { create(:instance, draft: false) }
+
+        before do
+          allow(product).to receive(:has_the_same_reference?).with(instance).and_return(true)
+        end
+
+        it 'cannot create_adnot on the instance' do
+          expect(subject.can?(:create_adnot, instance)).to eq false
+        end
+      end
+
+      context 'when product_from_context is nil' do
+        before do
+          allow(session_user).to receive(:product_from_context).and_return(nil)
+        end
+
+        it 'cannot create_adnot on the instance' do
+          expect(subject.can?(:create_adnot, instance)).to eq false
+        end
+      end
     end
 
   end
@@ -888,6 +942,69 @@ RSpec.describe Ability, type: :model do
 
     it 'can access instances tab_profile_v2' do
       expect(subject.can?("instances", "tab_profile_v2")).to eq true
+    end
+
+    it 'can access instances tab_comments' do
+      expect(subject.can?("instances", "tab_comments")).to eq true
+    end
+
+    it 'can access comments' do
+      expect(subject.can?("comments", :all)).to eq true
+    end
+
+    describe ':create_adnot permission' do
+      let(:user) { create(:user, id: 1, user_name: session_user.username) }
+      let(:tree) { create(:tree) }
+      let(:instance) { create(:instance, draft: false) }
+
+      before do
+        allow(product).to receive(:tree).and_return(tree)
+        product_role = create(:product_role, product: product)
+        create(:user_product_role, user: user, product_role: product_role)
+      end
+
+      context 'when instance is in a tree that user has access to' do
+        before do
+          allow(instance).to receive(:in_local_trees).and_return([tree])
+        end
+
+        it 'can create_adnot on the instance' do
+          expect(subject.can?(:create_adnot, instance)).to eq true
+        end
+      end
+
+      context 'when instance is in a tree that user does not have access to' do
+        let(:other_tree) { create(:tree) }
+
+        before do
+          allow(instance).to receive(:in_local_trees).and_return([other_tree])
+        end
+
+        it 'cannot create_adnot on the instance' do
+          expect(subject.can?(:create_adnot, instance)).to eq false
+        end
+      end
+
+      context 'when instance is not in any local trees' do
+        before do
+          allow(instance).to receive(:in_local_trees).and_return([])
+        end
+
+        it 'cannot create_adnot on the instance' do
+          expect(subject.can?(:create_adnot, instance)).to eq false
+        end
+      end
+
+      context 'when product has no tree' do
+        before do
+          allow(product).to receive(:tree).and_return(nil)
+          allow(instance).to receive(:in_local_trees).and_return([tree])
+        end
+
+        it 'cannot create_adnot on the instance' do
+          expect(subject.can?(:create_adnot, instance)).to eq false
+        end
+      end
     end
 
     it "can manage_profile on instance if not draft and has profile items for product" do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -955,12 +955,13 @@ RSpec.describe Ability, type: :model do
     describe ':create_adnot permission' do
       let(:user) { create(:user, id: 1, user_name: session_user.username) }
       let(:tree) { create(:tree) }
+      let(:product_with_tree) { create(:product, tree: tree) }
       let(:instance) { create(:instance, draft: false) }
 
       before do
-        allow(product).to receive(:tree).and_return(tree)
-        product_role = create(:product_role, product: product)
+        product_role = create(:product_role, product: product_with_tree)
         create(:user_product_role, user: user, product_role: product_role)
+        allow(session_user).to receive(:user).and_return(user)
       end
 
       context 'when instance is in a tree that user has access to' do
@@ -995,9 +996,13 @@ RSpec.describe Ability, type: :model do
         end
       end
 
-      context 'when product has no tree' do
+      context 'when user products have no trees' do
+        let(:product_without_tree) { create(:product, tree: nil) }
+
         before do
-          allow(product).to receive(:tree).and_return(nil)
+          user.user_product_roles.destroy_all
+          product_role = create(:product_role, product: product_without_tree)
+          create(:user_product_role, user: user, product_role: product_role)
           allow(instance).to receive(:in_local_trees).and_return([tree])
         end
 

--- a/spec/models/concerns/instance_treeable_spec.rb
+++ b/spec/models/concerns/instance_treeable_spec.rb
@@ -126,4 +126,82 @@ RSpec.describe InstanceTreeable do
       end
     end
   end
+
+  describe '#in_any_local_tree_ids?' do
+    let(:instance) { create(:instance) }
+    let(:tree) { create(:tree) }
+    let(:tree_version) { create(:tree_version, tree: tree) }
+    let(:tree_element) { create(:tree_element, instance: instance) }
+
+    context 'when tree_ids is blank' do
+      it 'returns false for empty array' do
+        expect(instance.in_any_local_tree_ids?([])).to eq false
+      end
+
+      it 'returns false for nil' do
+        expect(instance.in_any_local_tree_ids?(nil)).to eq false
+      end
+    end
+
+    context 'when instance is in one of the provided trees' do
+      before do
+        tree.update!(current_tree_version_id: tree_version.id)
+        create(:tree_version_element,
+          tree_element_id: tree_element.id,
+          tree_version_id: tree_version.id,
+          element_link: "test/#{tree_element.id}",
+          taxon_id: tree_element.id)
+      end
+
+      it 'returns true' do
+        expect(instance.in_any_local_tree_ids?([tree.id])).to eq true
+      end
+
+      it 'returns true when tree is among multiple tree_ids' do
+        other_tree = create(:tree)
+        expect(instance.in_any_local_tree_ids?([other_tree.id, tree.id])).to eq true
+      end
+    end
+
+    context 'when instance is not in any of the provided trees' do
+      let(:other_tree) { create(:tree) }
+
+      before do
+        tree.update!(current_tree_version_id: tree_version.id)
+        create(:tree_version_element,
+          tree_element_id: tree_element.id,
+          tree_version_id: tree_version.id,
+          element_link: "test/#{tree_element.id}",
+          taxon_id: tree_element.id)
+      end
+
+      it 'returns false' do
+        expect(instance.in_any_local_tree_ids?([other_tree.id])).to eq false
+      end
+    end
+
+    context 'when instance is not in any trees at all' do
+      it 'returns false' do
+        expect(instance.in_any_local_tree_ids?([tree.id])).to eq false
+      end
+    end
+
+    context 'when tree version is not current' do
+      let(:old_tree_version) { create(:tree_version, tree: tree) }
+      let(:current_tree_version) { create(:tree_version, tree: tree) }
+
+      before do
+        tree.update!(current_tree_version_id: current_tree_version.id)
+        create(:tree_version_element,
+          tree_element_id: tree_element.id,
+          tree_version_id: old_tree_version.id,
+          element_link: "test/old/#{tree_element.id}",
+          taxon_id: tree_element.id)
+      end
+
+      it 'returns false because instance is only in old version' do
+        expect(instance.in_any_local_tree_ids?([tree.id])).to eq false
+      end
+    end
+  end
 end

--- a/spec/models/concerns/instance_treeable_spec.rb
+++ b/spec/models/concerns/instance_treeable_spec.rb
@@ -129,9 +129,6 @@ RSpec.describe InstanceTreeable do
 
   describe '#in_any_local_tree_ids?' do
     let(:instance) { create(:instance) }
-    let(:tree) { create(:tree) }
-    let(:tree_version) { create(:tree_version, tree: tree) }
-    let(:tree_element) { create(:tree_element, instance: instance) }
 
     context 'when tree_ids is blank' do
       it 'returns false for empty array' do
@@ -144,12 +141,16 @@ RSpec.describe InstanceTreeable do
     end
 
     context 'when instance is in one of the provided trees' do
+      let(:tree) { create(:tree, is_read_only: false) }
+      let(:tree_version) { create(:tree_version, tree: tree, draft_name: "In Tree Draft") }
+      let(:tree_element) { create(:tree_element, instance: instance) }
+
       before do
         tree.update!(current_tree_version_id: tree_version.id)
         create(:tree_version_element,
           tree_element_id: tree_element.id,
           tree_version_id: tree_version.id,
-          element_link: "test/#{tree_element.id}",
+          element_link: "test/in_tree/#{tree_element.id}",
           taxon_id: tree_element.id)
       end
 
@@ -164,14 +165,17 @@ RSpec.describe InstanceTreeable do
     end
 
     context 'when instance is not in any of the provided trees' do
+      let(:tree) { create(:tree, is_read_only: false) }
       let(:other_tree) { create(:tree) }
+      let(:tree_version) { create(:tree_version, tree: tree, draft_name: "Not In Draft") }
+      let(:tree_element) { create(:tree_element, instance: instance) }
 
       before do
         tree.update!(current_tree_version_id: tree_version.id)
         create(:tree_version_element,
           tree_element_id: tree_element.id,
           tree_version_id: tree_version.id,
-          element_link: "test/#{tree_element.id}",
+          element_link: "test/not_in/#{tree_element.id}",
           taxon_id: tree_element.id)
       end
 
@@ -181,14 +185,18 @@ RSpec.describe InstanceTreeable do
     end
 
     context 'when instance is not in any trees at all' do
+      let(:tree) { create(:tree) }
+
       it 'returns false' do
         expect(instance.in_any_local_tree_ids?([tree.id])).to eq false
       end
     end
 
     context 'when tree version is not current' do
-      let(:old_tree_version) { create(:tree_version, tree: tree) }
-      let(:current_tree_version) { create(:tree_version, tree: tree) }
+      let(:tree) { create(:tree, is_read_only: false) }
+      let(:old_tree_version) { create(:tree_version, tree: tree, draft_name: "Old Draft") }
+      let(:current_tree_version) { create(:tree_version, tree: tree, draft_name: "Current Draft") }
+      let(:tree_element) { create(:tree_element, instance: instance) }
 
       before do
         tree.update!(current_tree_version_id: current_tree_version.id)

--- a/spec/views/instances/tabs/tabs_all_tab_headings_partial_spec.rb
+++ b/spec/views/instances/tabs/tabs_all_tab_headings_partial_spec.rb
@@ -234,6 +234,36 @@ RSpec.describe("instances/tabs/_all_tab_headings.html.erb", type: :view) do
     end
   end
 
+  context "when 'tab_comments' is offered with multi_product_tabs_enabled" do
+    before do
+      tabs_to_offer << "tab_comments"
+      allow(view).to(receive(:can?).with("comments", "create").and_return(true))
+      allow(Rails.configuration).to(receive(:multi_product_tabs_enabled).and_return(true))
+    end
+
+    context "when user can create_adnot on the instance" do
+      before do
+        allow(view).to(receive(:can?).with(:create_adnot, instance).and_return(true))
+      end
+
+      it "renders the 'Adnot' tab" do
+        render
+        expect(rendered).to(have_selector("a#instance-comments-tab", text: "Adnot"))
+      end
+    end
+
+    context "when user cannot create_adnot on the instance" do
+      before do
+        allow(view).to(receive(:can?).with(:create_adnot, instance).and_return(false))
+      end
+
+      it "does not render the 'Adnot' tab" do
+        render
+        expect(rendered).not_to(have_selector("a#instance-comments-tab"))
+      end
+    end
+  end
+
   context "when 'tab_copy_to_new_reference' is offered and the user has permission" do
     before do
       tabs_to_offer << "tab_copy_to_new_reference"

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -68,72 +68,62 @@ class CommentsControllerTest < ActionController::TestCase
   end
 
   test "should create comment when multi_product_tabs_enabled is false" do
-    Rails.configuration.stubs(:multi_product_tabs_enabled).returns(false)
-
-    assert_difference("Comment.count") do
-      post(:create,
-           params: { comment: { text: "Test comment", instance_id: instances(:britten_created_name_to_be_deleted).id } },
-           session: { username: "fred",
-                      user_full_name: "Fred Jones",
-                      groups: ["edit"] },
-           xhr: true)
-    end
-  end
-
-  test "should create comment when multi_product_tabs_enabled is true and user can create_adnot" do
-    Rails.configuration.stubs(:multi_product_tabs_enabled).returns(true)
-    instance = instances(:britten_created_name_to_be_deleted)
-
-    @controller.stubs(:can?).with(:create_adnot, instance).returns(true)
-    @controller.stubs(:can?).with(anything, anything).returns(true)
-
-    assert_difference("Comment.count") do
-      post(:create,
-           params: { comment: { text: "Test comment", instance_id: instance.id } },
-           session: { username: "fred",
-                      user_full_name: "Fred Jones",
-                      groups: ["edit"] },
-           xhr: true)
-    end
-  end
-
-  test "should deny create comment when multi_product_tabs_enabled is true and user cannot create_adnot" do
-    Rails.configuration.stubs(:multi_product_tabs_enabled).returns(true)
-    instance = instances(:britten_created_name_to_be_deleted)
-
-    ability = Object.new
-    ability.stubs(:can?).returns(true)
-    ability.stubs(:can?).with(:create_adnot, instance).returns(false)
-    @controller.stubs(:current_ability).returns(ability)
-
-    assert_no_difference("Comment.count") do
-      post(:create,
-           params: { comment: { text: "Test comment", instance_id: instance.id } },
-           session: { username: "fred",
-                      user_full_name: "Fred Jones",
-                      groups: ["edit"] },
-           xhr: true)
-    end
-    assert_response :forbidden
-  end
-
-  test "should deny destroy comment when multi_product_tabs_enabled is true and user cannot create_adnot" do
-    Rails.configuration.stubs(:multi_product_tabs_enabled).returns(true)
-    comment = comments(:instance_comment)
-
-    ability = Object.new
-    ability.stubs(:can?).returns(true)
-    ability.stubs(:can?).with(:create_adnot, comment.instance).returns(false)
-    @controller.stubs(:current_ability).returns(ability)
-
-    assert_no_difference("Comment.count") do
-      delete(:destroy,
-             params: { id: comment.id },
+    CommentsController.stub_any_instance(:authorize_for_instance!, nil) do
+      assert_difference("Comment.count") do
+        post(:create,
+             params: { comment: { text: "Test comment", instance_id: instances(:triodia_in_brassard).id } },
              session: { username: "fred",
                         user_full_name: "Fred Jones",
                         groups: ["edit"] },
              xhr: true)
+      end
     end
-    assert_response :forbidden
+  end
+
+  test "should create comment when multi_product_tabs_enabled is true and user can create_adnot" do
+    instance = instances(:triodia_in_brassard)
+
+    CommentsController.stub_any_instance(:authorize_for_instance!, nil) do
+      assert_difference("Comment.count") do
+        post(:create,
+             params: { comment: { text: "Test comment", instance_id: instance.id } },
+             session: { username: "fred",
+                        user_full_name: "Fred Jones",
+                        groups: ["edit"] },
+             xhr: true)
+      end
+    end
+  end
+
+  test "should deny create comment when multi_product_tabs_enabled is true and user cannot create_adnot" do
+    instance = instances(:triodia_in_brassard)
+
+    CommentsController.stub_any_instance(:authorize_for_instance!, -> { raise CanCan::AccessDenied.new("Access Denied!", :create_adnot, instance) }) do
+      assert_no_difference("Comment.count") do
+        post(:create,
+             params: { comment: { text: "Test comment", instance_id: instance.id } },
+             session: { username: "fred",
+                        user_full_name: "Fred Jones",
+                        groups: ["edit"] },
+             xhr: true)
+      end
+      assert_response :forbidden
+    end
+  end
+
+  test "should deny destroy comment when multi_product_tabs_enabled is true and user cannot create_adnot" do
+    comment = comments(:instance_comment)
+
+    CommentsController.stub_any_instance(:authorize_for_instance!, -> { raise CanCan::AccessDenied.new("Access Denied!", :create_adnot, comment.instance) }) do
+      assert_no_difference("Comment.count") do
+        delete(:destroy,
+               params: { id: comment.id },
+               session: { username: "fred",
+                          user_full_name: "Fred Jones",
+                          groups: ["edit"] },
+               xhr: true)
+      end
+      assert_response :forbidden
+    end
   end
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -66,4 +66,74 @@ class CommentsControllerTest < ActionController::TestCase
              xhr: true)
     end
   end
+
+  test "should create comment when multi_product_tabs_enabled is false" do
+    Rails.configuration.stubs(:multi_product_tabs_enabled).returns(false)
+
+    assert_difference("Comment.count") do
+      post(:create,
+           params: { comment: { text: "Test comment", instance_id: instances(:britten_created_name_to_be_deleted).id } },
+           session: { username: "fred",
+                      user_full_name: "Fred Jones",
+                      groups: ["edit"] },
+           xhr: true)
+    end
+  end
+
+  test "should create comment when multi_product_tabs_enabled is true and user can create_adnot" do
+    Rails.configuration.stubs(:multi_product_tabs_enabled).returns(true)
+    instance = instances(:britten_created_name_to_be_deleted)
+
+    @controller.stubs(:can?).with(:create_adnot, instance).returns(true)
+    @controller.stubs(:can?).with(anything, anything).returns(true)
+
+    assert_difference("Comment.count") do
+      post(:create,
+           params: { comment: { text: "Test comment", instance_id: instance.id } },
+           session: { username: "fred",
+                      user_full_name: "Fred Jones",
+                      groups: ["edit"] },
+           xhr: true)
+    end
+  end
+
+  test "should deny create comment when multi_product_tabs_enabled is true and user cannot create_adnot" do
+    Rails.configuration.stubs(:multi_product_tabs_enabled).returns(true)
+    instance = instances(:britten_created_name_to_be_deleted)
+
+    ability = Object.new
+    ability.stubs(:can?).returns(true)
+    ability.stubs(:can?).with(:create_adnot, instance).returns(false)
+    @controller.stubs(:current_ability).returns(ability)
+
+    assert_no_difference("Comment.count") do
+      post(:create,
+           params: { comment: { text: "Test comment", instance_id: instance.id } },
+           session: { username: "fred",
+                      user_full_name: "Fred Jones",
+                      groups: ["edit"] },
+           xhr: true)
+    end
+    assert_response :forbidden
+  end
+
+  test "should deny destroy comment when multi_product_tabs_enabled is true and user cannot create_adnot" do
+    Rails.configuration.stubs(:multi_product_tabs_enabled).returns(true)
+    comment = comments(:instance_comment)
+
+    ability = Object.new
+    ability.stubs(:can?).returns(true)
+    ability.stubs(:can?).with(:create_adnot, comment.instance).returns(false)
+    @controller.stubs(:current_ability).returns(ability)
+
+    assert_no_difference("Comment.count") do
+      delete(:destroy,
+             params: { id: comment.id },
+             session: { username: "fred",
+                        user_full_name: "Fred Jones",
+                        groups: ["edit"] },
+             xhr: true)
+    end
+    assert_response :forbidden
+  end
 end


### PR DESCRIPTION
## Description
This pull request implements fine-grained permissions for the "Adnot" (comments) feature, specifically for users with draft-profile-editor and profile-editor roles, and ensures that the "Adnot" tab and related actions are only accessible when the user has the correct permissions. It introduces a new `:create_adnot` permission, updates the authorization logic, and adds comprehensive tests for these changes.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
