### PR TITLE
FLOR-206 Add common name editor role with permissions for creating an…

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -68,6 +68,7 @@ class Ability
     tree_builder_auth(user) if user.with_role?('tree-builder')
     tree_publisher_auth(user) if user.with_role?('tree-publisher')
     name_index_editor(user) if user.with_role?('name-index-editor') && is_name_index
+    common_name_editor(user) if user.with_role?('common-name') && not_name_index
     product_admin_auth(user) if user.with_role?('admin')
   end
 
@@ -281,6 +282,32 @@ class Ability
     can "references",         :all
     can "names/typeaheads/for_unpub_cit", :all
     can "loader/batch/review/mode", "switch_off"
+  end
+
+  # For common-name product roles - allows creating and editing common names only
+  def common_name_editor(session_user)
+    # Name creation - restricted to common names only (via form restrictions)
+    can :create, Name
+    can :create_common_name, Name
+
+    # Name update - only for common name types
+    can :update, Name do |name|
+      name.name_type&.name&.downcase == "common"
+    end
+    can :update_common_name, Name do |name|
+      name.name_type&.name&.downcase == "common"
+    end
+
+    # Menu access for "New" dropdown
+    can "menu", "new"
+
+    # Name controller actions
+    can "names", "new_row"
+    can "names", "new"
+    can "names", "create"
+    can "names", "tab_details"
+    can "names", "tab_edit"
+    can "names", "update"
   end
 
   def basic_auth_1

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -68,7 +68,7 @@ class Ability
     tree_builder_auth(user) if user.with_role?('tree-builder')
     tree_publisher_auth(user) if user.with_role?('tree-publisher')
     name_index_editor(user) if user.with_role?('name-index-editor') && is_name_index
-    common_name_editor(user) if user.with_role?('common-name') && not_name_index
+    common_name_editor(user) if user.with_role_for_context?('common-name') && not_name_index
     product_admin_auth(user) if user.with_role?('admin')
   end
 
@@ -287,6 +287,7 @@ class Ability
   # For common-name product roles - allows creating and editing common names only
   def common_name_editor(session_user)
     # Name creation - restricted to common names only (via form restrictions)
+    can :access_menu, :names
     can :create, Name
     can :create_common_name, Name
 
@@ -342,7 +343,9 @@ class Ability
   end
 
   def edit_auth
-    can :manage,              Author
+    can :access_menu, :all
+    can :manage, Author
+    can :manage, Name
     can :manage, Reference
     can [
       :create,
@@ -416,6 +419,7 @@ class Ability
 
   def admin_auth
     can "admin",              :all
+    can :access_menu, :all
     can "menu",               "admin"
     can "users",              :all
     can "user/product_roles", :all

--- a/app/models/name_type.rb
+++ b/app/models/name_type.rb
@@ -180,6 +180,12 @@ class NameType < ApplicationRecord
     end
   end
 
+  def self.common_only_options
+    where("lower(name) = ?", "common")
+      .sort_by(&:name)
+      .map { |n| [n.name, n.id, { class: "other" }] }
+  end
+
   def hybrid?
     hybrid
   end

--- a/app/models/session_user.rb
+++ b/app/models/session_user.rb
@@ -37,6 +37,16 @@ class SessionUser < ActiveType::Object
     user.is?(requested_role_name)
   end
 
+  def with_role_for_context?(requested_role_name)
+    return false unless user && product_from_context
+
+    user.user_product_roles
+        .joins(product_role: :role)
+        .where(product_role: { product_id: product_from_context.id },
+               roles: { name: requested_role_name })
+        .exists?
+  end
+
   #
   # Profile V2
   #

--- a/app/views/layouts/_new_multi_product_menu.html.erb
+++ b/app/views/layouts/_new_multi_product_menu.html.erb
@@ -9,7 +9,7 @@
   </a>
   <% name_tabs_array = product_tab_service.all_available_tabs.dig('name')&.map{|tab| tab[:tab] } || [] %>
   <ul id="create-dropdown-menu" class="dropdown-menu" role="menu">
-    <% if tab_available?(name_tabs_array, "new") %>
+    <% if can?(:access_menu, :names) %>
       <li class="dropdown-submenu">
         <a tabindex="-1" href="#" title="Names stuff"> Names </a>
         <%= render partial: 'layouts/new_name_sub_menu' %>

--- a/app/views/layouts/_new_name_sub_menu.html.erb
+++ b/app/views/layouts/_new_name_sub_menu.html.erb
@@ -1,79 +1,87 @@
-          <ul id="create-name-dropdown-submenu" class="dropdown-menu" role="menu">
+<ul id="create-name-dropdown-submenu" class="dropdown-menu" role="menu">
+<% if can?(:manage, Name) %>
+  <li role="presentation">
+    <%= link_to "Scientific name",
+                name_new_row_path('scientific'),
+                title: 'Add a new scientific name',
+                remote: true,
+                tabindex: '-1' %>
+  </li>
 
-            <li role="presentation">
-              <%= link_to "Scientific name",
-                          name_new_row_path('scientific'),
-                          title: 'Add a new scientific name',
-                          remote: true,
-                          tabindex: '-1' %>
-            </li>
+  <li role="presentation">
+    <%= link_to "Scientific name family or above",
+                name_new_row_path('scientific-family-or-above'),
+                title: 'Add a new scientific name family and above',
+                remote: true,
+                tabindex: '-1' %>
+  </li>
 
+  <li role="presentation">
+    <%= link_to "Phrase name",
+                name_new_row_path('phrase'),
+                title: 'Add a new phrase name',
+                remote: true,
+                tabindex: '-1' %>
+  </li>
 
-            <li role="presentation">
-              <%= link_to "Scientific name family or above",
-                          name_new_row_path('scientific-family-or-above'),
-                          title: 'Add a new scientific name family and above',
-                          remote: true,
-                          tabindex: '-1' %>
-            </li>
+  <li role="presentation" class="divider"></li>
+  <li role="presentation">
+    <%= link_to "Named Hybrid",
+                name_new_row_path('named-hybrid'),
+                title: 'Add a new named hybrid',
+                remote: true,
+                tabindex: '-1' %>
+  </li>
+  <li role="presentation">
+    <%= link_to "Hybrid formula name",
+                name_new_row_path('hybrid formula'),
+                title: 'Add a new hybrid name',
+                remote: true,
+                tabindex: '-1' %>
+  </li>
 
-            <li role="presentation">
-              <%= link_to "Phrase name",
-                          name_new_row_path('phrase'),
-                          title: 'Add a new phrase name',
-                          remote: true,
-                          tabindex: '-1' %>
-            </li>
+  <li role="presentation">
+    <%= link_to "Hybrid formula unknown 2nd parent name",
+                name_new_row_path('hybrid-formula-unknown-2nd-parent'),
+                title: 'Add a new hybrid formula unknown 2nd parent name',
+                remote: true,
+                tabindex: '-1' %>
+  </li>
+  <li role="presentation" class="divider"></li>
 
-            <li role="presentation" class="divider"></li>
-            <li role="presentation">
-              <%= link_to "Named Hybrid",
-                          name_new_row_path('named-hybrid'),
-                          title: 'Add a new named hybrid',
-                          remote: true,
-                          tabindex: '-1' %>
-            </li>
-            <li role="presentation">
-              <%= link_to "Hybrid formula name",
-                          name_new_row_path('hybrid formula'),
-                          title: 'Add a new hybrid name',
-                          remote: true,
-                          tabindex: '-1' %>
-            </li>
+  <li role="presentation">
+    <%= link_to "Cultivar hybrid name",
+                name_new_row_path('cultivar-hybrid'),
+                title: 'Add a new cultivar hybrid name',
+                remote: true,
+                tabindex: '-1' %>
+  </li>
 
-            <li role="presentation">
-              <%= link_to "Hybrid formula unknown 2nd parent name",
-                          name_new_row_path('hybrid-formula-unknown-2nd-parent'),
-                          title: 'Add a new hybrid formula unknown 2nd parent name',
-                          remote: true,
-                          tabindex: '-1' %>
-            </li>
-            <li role="presentation" class="divider"></li>
+  <li role="presentation">
+    <%= link_to "Cultivar name",
+                name_new_row_path('cultivar'),
+                title: 'Add a new cultivar name',
+                remote: true,
+                tabindex: '-1' %>
+  </li>
 
-            <li role="presentation">
-              <%= link_to "Cultivar hybrid name",
-                          name_new_row_path('cultivar-hybrid'),
-                          title: 'Add a new cultivar hybrid name',
-                          remote: true,
-                          tabindex: '-1' %>
-            </li>
+  <li role="presentation" class="divider"></li>
 
-            <li role="presentation">
-              <%= link_to "Cultivar name",
-                          name_new_row_path('cultivar'),
-                          title: 'Add a new cultivar name',
-                          remote: true,
-                          tabindex: '-1' %>
-            </li>
+  <li role="presentation">
+    <%= link_to "Other name",
+                name_new_row_path('other'),
+                title: 'Add a new other name',
+                remote: true,
+                tabindex: '-1' %>
+  </li>
+<% elsif can?(:create_common_name, Name) %>
+    <li role="presentation">
+      <%= link_to "Other name",
+                  name_new_row_path('other'),
+                  title: 'Add a new other name',
+                  remote: true,
+                  tabindex: '-1' %>
+    </li>
+<% end %>
 
-            <li role="presentation" class="divider"></li>
-
-            <li role="presentation">
-              <%= link_to "Other name",
-                          name_new_row_path('other'),
-                          title: 'Add a new other name',
-                          remote: true,
-                          tabindex: '-1' %>
-            </li>
-
-          </ul>
+</ul>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,8 @@
+- :date: 24-Apr-2026
+  :jira_id: '206'
+  :jira_project: FLOR
+  :description: |-
+    Add a common-name product role and give it permissions to create new common names
 - :date: 20-Apr-2026
   :jira_id: '205'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.2.7
+appversion=5.1.2.8

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1224,7 +1224,7 @@ RSpec.describe Ability, type: :model do
 
   describe "#common_name_editor role" do
     let(:product) { create(:product, is_name_index: false, manages_profile: true) }
-    let(:common_name_type) { create(:name_type, name: "common") }
+    let(:common_name_type) { create(:name_type, name: "common", name_category: create(:name_category, name: "other")) }
     let(:scientific_name_type) { create(:name_type, name: "scientific", scientific: true) }
     let(:common_name) { create(:name, name_type: common_name_type, full_name: "Common Daisy") }
     let(:scientific_name) { create(:name, name_type: scientific_name_type, full_name: "Bellis perennis") }

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Ability, type: :model do
     allow(session_user).to receive(:with_role?).with('tree-publisher').and_return(false)
     allow(session_user).to receive(:with_role?).with('tree-reviewer').and_return(false)
     allow(session_user).to receive(:with_role?).with('name-index-editor').and_return(false)
-    allow(session_user).to receive(:with_role?).with('common-name').and_return(false)
+    allow(session_user).to receive(:with_role_for_context?).with('common-name').and_return(false)
     allow(session_user).to receive(:with_role?).with('admin').and_return(false)
     allow(session_user).to receive(:user_id).and_return(1)
     allow(session_user).to receive(:product_from_context).and_return(nil)
@@ -1230,12 +1230,16 @@ RSpec.describe Ability, type: :model do
     let(:scientific_name) { create(:name, name_type: scientific_name_type, full_name: "Bellis perennis") }
 
     before do
-      allow(session_user).to receive(:with_role?).with('common-name').and_return(true)
+      allow(session_user).to receive(:with_role_for_context?).with('common-name').and_return(true)
       allow(session_user).to receive(:product_from_context).and_return(product)
       allow(product).to receive(:is_name_index?).and_return(false)
     end
 
     context "when managing names" do
+      it "allows access_menu on :names" do
+        expect(subject.can?(:access_menu, :names)).to eq true
+      end
+
       it "allows creating Name" do
         expect(subject.can?(:create, Name)).to eq true
       end
@@ -1269,6 +1273,25 @@ RSpec.describe Ability, type: :model do
       it 'cannot create Name (not_name_index restriction)' do
         # The initialize method checks not_name_index before calling common_name_editor
         expect(subject.can?(:create, Name)).to eq false
+      end
+    end
+
+    context 'when product_from_context is nil' do
+      before do
+        allow(session_user).to receive(:with_role_for_context?).with('common-name').and_return(false)
+        allow(session_user).to receive(:product_from_context).and_return(nil)
+      end
+
+      it 'cannot create Name' do
+        expect(subject.can?(:create, Name)).to eq false
+      end
+
+      it 'cannot create_common_name' do
+        expect(subject.can?(:create_common_name, Name)).to eq false
+      end
+
+      it 'cannot access menu new' do
+        expect(subject.can?("menu", "new")).to eq false
       end
     end
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe Ability, type: :model do
     allow(session_user).to receive(:with_role?).with('tree-publisher').and_return(false)
     allow(session_user).to receive(:with_role?).with('tree-reviewer').and_return(false)
     allow(session_user).to receive(:with_role?).with('name-index-editor').and_return(false)
+    allow(session_user).to receive(:with_role?).with('common-name').and_return(false)
     allow(session_user).to receive(:with_role?).with('admin').and_return(false)
     allow(session_user).to receive(:user_id).and_return(1)
     allow(session_user).to receive(:product_from_context).and_return(nil)
@@ -1219,6 +1220,87 @@ RSpec.describe Ability, type: :model do
       end
     end
 
+  end
+
+  describe "#common_name_editor role" do
+    let(:product) { create(:product, is_name_index: false, manages_profile: true) }
+    let(:common_name_type) { create(:name_type, name: "common") }
+    let(:scientific_name_type) { create(:name_type, name: "scientific", scientific: true) }
+    let(:common_name) { create(:name, name_type: common_name_type, full_name: "Common Daisy") }
+    let(:scientific_name) { create(:name, name_type: scientific_name_type, full_name: "Bellis perennis") }
+
+    before do
+      allow(session_user).to receive(:with_role?).with('common-name').and_return(true)
+      allow(session_user).to receive(:product_from_context).and_return(product)
+      allow(product).to receive(:is_name_index?).and_return(false)
+    end
+
+    context "when managing names" do
+      it "allows creating Name" do
+        expect(subject.can?(:create, Name)).to eq true
+      end
+
+      it "allows create_common_name action" do
+        expect(subject.can?(:create_common_name, Name)).to eq true
+      end
+
+      it "allows updating common name types" do
+        expect(subject.can?(:update, common_name)).to eq true
+      end
+
+      it "does not allow updating non-common name types" do
+        expect(subject.can?(:update, scientific_name)).to eq false
+      end
+
+      it "allows update_common_name for common names" do
+        expect(subject.can?(:update_common_name, common_name)).to eq true
+      end
+
+      it "does not allow update_common_name for non-common names" do
+        expect(subject.can?(:update_common_name, scientific_name)).to eq false
+      end
+    end
+
+    context 'when product is a name index' do
+      before do
+        allow(product).to receive(:is_name_index?).and_return(true)
+      end
+
+      it 'cannot create Name (not_name_index restriction)' do
+        # The initialize method checks not_name_index before calling common_name_editor
+        expect(subject.can?(:create, Name)).to eq false
+      end
+    end
+
+    context "when accessing specific actions" do
+      it "allows accessing the 'new' menu" do
+        expect(subject.can?("menu", "new")).to eq true
+      end
+
+      it "allows names new_row action" do
+        expect(subject.can?("names", "new_row")).to eq true
+      end
+
+      it "allows names new action" do
+        expect(subject.can?("names", "new")).to eq true
+      end
+
+      it "allows names create action" do
+        expect(subject.can?("names", "create")).to eq true
+      end
+
+      it "allows names tab_details action" do
+        expect(subject.can?("names", "tab_details")).to eq true
+      end
+
+      it "allows names tab_edit action" do
+        expect(subject.can?("names", "tab_edit")).to eq true
+      end
+
+      it "allows names update action" do
+        expect(subject.can?("names", "update")).to eq true
+      end
+    end
   end
 
   describe "#basic_auth_2" do

--- a/spec/models/name_type_spec.rb
+++ b/spec/models/name_type_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe NameType, type: :model do
+  describe ".common_only_options" do
+    let!(:common_name_type) { create(:name_type, name: "common") }
+    let!(:vernacular_name_type) { create(:name_type, name: "vernacular") }
+    let!(:scientific_name_type) { create(:name_type, name: "scientific", scientific: true) }
+
+    it "returns only the common name type" do
+      options = NameType.common_only_options
+      expect(options.length).to eq 1
+    end
+
+    it "returns the common name type with correct structure" do
+      options = NameType.common_only_options
+      expect(options.first).to eq ["common", common_name_type.id, { class: "other" }]
+    end
+
+    it "does not include vernacular name types" do
+      options = NameType.common_only_options
+      names = options.map(&:first)
+      expect(names).not_to include("vernacular")
+    end
+
+    it "does not include scientific name types" do
+      options = NameType.common_only_options
+      names = options.map(&:first)
+      expect(names).not_to include("scientific")
+    end
+
+    it "is case-insensitive for 'common'" do
+      # Create a name type with different case
+      common_uppercase = create(:name_type, name: "COMMON")
+
+      options = NameType.common_only_options
+      names = options.map(&:first)
+
+      expect(names).to include("common")
+      expect(names).to include("COMMON")
+    end
+  end
+end

--- a/spec/models/session_user_spec.rb
+++ b/spec/models/session_user_spec.rb
@@ -161,6 +161,66 @@ RSpec.describe SessionUser, type: :model do
     end
   end
 
+  describe '#with_role_for_context?' do
+    let(:username) { 'testuser' }
+    let(:full_name) { 'Test User' }
+    let(:groups) { ['group1'] }
+
+    let!(:user) { FactoryBot.create(:user, user_name: username) }
+    let!(:product) { FactoryBot.create(:product) }
+    let!(:role) { FactoryBot.create(:role, name: 'common-name') }
+    let!(:other_product) { FactoryBot.create(:product) }
+    let!(:product_role) { FactoryBot.create(:product_role, product: product, role: role) }
+    let!(:user_product_role) { FactoryBot.create(:user_product_role, product_role: product_role, user: user) }
+
+    let(:session_user) { FactoryBot.create(:session_user, username: username, groups: groups) }
+
+    context 'when user is present and product_from_context is set' do
+      before do
+        session_user.set_current_product_from_context(product)
+      end
+
+      context 'when the user has the role for the context product' do
+        it 'returns true' do
+          expect(session_user.with_role_for_context?('common-name')).to be true
+        end
+      end
+
+      context 'when the user does not have the role for the context product' do
+        it 'returns false for an unassigned role name' do
+          expect(session_user.with_role_for_context?('admin')).to be false
+        end
+      end
+
+      context 'when the user has the role but for a different product' do
+        before do
+          session_user.set_current_product_from_context(other_product)
+        end
+
+        it 'returns false' do
+          expect(session_user.with_role_for_context?('common-name')).to be false
+        end
+      end
+    end
+
+    context 'when product_from_context is nil' do
+      it 'returns false' do
+        expect(session_user.with_role_for_context?('common-name')).to be false
+      end
+    end
+
+    context 'when user is not present' do
+      before do
+        allow(session_user).to receive(:user).and_return(nil)
+        session_user.set_current_product_from_context(product)
+      end
+
+      it 'returns false' do
+        expect(session_user.with_role_for_context?('common-name')).to be false
+      end
+    end
+  end
+
   describe "#user" do
     let(:username) { "test" }
     let!(:user) { FactoryBot.create(:user, user_name: username) }


### PR DESCRIPTION
## Description
This pull request introduces a new "common-name" product role, allowing users with this role to create and edit only common names within the application. It includes changes to the authorization logic, menu visibility, and supporting model methods.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
