### PR TITLE
FLOR-206 Refactor name type selection logic and enhance tab visibilit…

### DIFF
--- a/app/views/names/form/_name_type.html.erb
+++ b/app/views/names/form/_name_type.html.erb
@@ -1,8 +1,16 @@
   <div class="form-group margin-top-1em">
     <label for="name_type_id">Type*</label>
-    <% if @name.category_for_edit.only_one_type? %>
+    <%
+      name_type_options = if can?(:create_common_name, Name) && !can?(:manage, Name) && @name.category_for_edit.other?
+                            NameType.common_only_options
+                          else
+                            NameType.options_for_category(@name.category_for_edit)
+                          end
+      show_prompt = @name.category_for_edit.only_one_type? || (can?(:create_common_name, Name) && !can?(:manage, Name))
+    %>
+    <% if show_prompt %>
       <%= f.select('name_type_id',
-                   NameType.options_for_category(@name.category_for_edit),
+                   name_type_options,
                    {prompt: 'Choose one'},
                    id: "name-type-selector",
                    title: 'Select type',
@@ -12,7 +20,7 @@
                    required: true) %>
     <% else %>
       <%= f.select('name_type_id',
-                   NameType.options_for_category(@name.category_for_edit),
+                   name_type_options,
                    {},
                    title: 'Select type',
                    tabindex: increment_tab_index,

--- a/app/views/names/tabs/_tabs.html.erb
+++ b/app/views/names/tabs/_tabs.html.erb
@@ -19,7 +19,14 @@
     })
   %>
 
-  <% if can?("names", "update") && tab_available?(tabs_array, "edit") %>
+  <%
+    can_edit_this_name = if can?(:manage, Name)
+                            true
+                          elsif can?(:update_common_name, @name) && !can?(:manage, Name)
+                            @name.name_type&.name&.downcase == "common"
+                          end
+  %>
+  <% if can?("names", "update") && can_edit_this_name %>
     <%= render(
       partial: "names/tabs/tab",
       locals: {

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,8 @@
+- :date: 28-Apr-2026
+  :jira_id: '206'
+  :jira_project: FLOR
+  :description: |-
+    Display the common name form and edit common name tab for users with the common-name product role
 - :date: 24-Apr-2026
   :jira_id: '206'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.2.8
+appversion=5.1.2.9

--- a/spec/views/names/tabs/tabs_partial_spec.rb
+++ b/spec/views/names/tabs/tabs_partial_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe("names/tabs/_tabs.html.erb", type: :view) do
     allow(view).to(receive(:can?).with("names", "delete").and_return(false))
     allow(view).to(receive(:can?).with(:create_with_product_reference, Instance).and_return(false))
     allow(view).to(receive(:can?).with(:create, Instance).and_return(true))
+    allow(view).to(receive(:can?).with(:manage, Name).and_return(false))
+    allow(view).to(receive(:can?).with(:update_common_name, name).and_return(false))
+    allow(view).to(receive(:can?).with(:create_common_name, Name).and_return(false))
     allow(view).to(receive(:increment_tab_index).and_return(1))
     
     mock_service = product_tab_service_mock
@@ -57,6 +60,7 @@ RSpec.describe("names/tabs/_tabs.html.erb", type: :view) do
   context "when the user can update names" do
     before do
       allow(view).to(receive(:can?).with("names", "update").and_return(true))
+      allow(view).to(receive(:can?).with(:manage, Name).and_return(true))
     end
 
     it "renders the Edit tab" do
@@ -106,6 +110,7 @@ RSpec.describe("names/tabs/_tabs.html.erb", type: :view) do
   context "when a user can update a name" do
     before do
       allow(view).to(receive(:can?).with("names", "update").and_return(true))
+      allow(view).to(receive(:can?).with(:manage, Name).and_return(true))
     end
 
     it "renders the Edit tab" do

--- a/test/controllers/names/tabs/for_common_name_role/hide_edit_tab_for_scientific_name_test.rb
+++ b/test/controllers/names/tabs/for_common_name_role/hide_edit_tab_for_scientific_name_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Common-name role: edit tab is hidden for non-common (scientific) names.
+class CommonNameRoleHideEditTabForScientificNameTest < ActionController::TestCase
+  tests NamesController
+  setup do
+    @name = names(:a_species)
+  end
+
+  test "common-name role user does not see edit tab for a scientific name" do
+    @request.headers["Accept"] = "application/javascript"
+    SessionUser.stub_any_instance(:with_role_for_context?, true) do
+      get(:show,
+          params: { id: @name.id, tab: "tab_details" },
+          session: { username: "fred",
+                     user_full_name: "Fred Jones",
+                     groups: [] })
+    end
+    assert_response :success
+    assert_select "a#name-edit-tab", false, "Should not show 'Edit' tab link for scientific name."
+  end
+end

--- a/test/controllers/names/tabs/for_common_name_role/show_edit_tab_for_common_name_test.rb
+++ b/test/controllers/names/tabs/for_common_name_role/show_edit_tab_for_common_name_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Common-name role: edit tab and restricted name type options for a common name.
+class CommonNameRoleShowEditTabForCommonNameTest < ActionController::TestCase
+  tests NamesController
+  setup do
+    @name = names(:argyle_apple)
+  end
+
+  test "common-name role user sees edit tab and common-only name type options for a common name" do
+    @request.headers["Accept"] = "application/javascript"
+    SessionUser.stub_any_instance(:with_role_for_context?, true) do
+      get(:show,
+          params: { id: @name.id, tab: "tab_edit" },
+          session: { username: "fred",
+                     user_full_name: "Fred Jones",
+                     groups: [] })
+    end
+    assert_response :success
+    assert_select "a#name-edit-tab", true, "Should show 'Edit' tab link for common name."
+    assert_select "select#name_name_type_id", true
+    assert_select "select#name_name_type_id option[value='']", true,
+                  "Should include prompt option for common-name role user."
+  end
+end

--- a/test/controllers/names/tabs/for_common_name_role/show_edit_tab_for_common_name_test.rb
+++ b/test/controllers/names/tabs/for_common_name_role/show_edit_tab_for_common_name_test.rb
@@ -36,8 +36,9 @@ class CommonNameRoleShowEditTabForCommonNameTest < ActionController::TestCase
     end
     assert_response :success
     assert_select "a#name-edit-tab", true, "Should show 'Edit' tab link for common name."
-    assert_select "select#name_name_type_id", true
-    assert_select "select#name_name_type_id option[value='']", true,
-                  "Should include prompt option for common-name role user."
+    assert_select "select#name-type-selector", true,
+                  "Should render name type select via the show_prompt branch."
+    assert_select "select#name-type-selector option", {count: 1},
+                  "Should show only the common name type option, not the full other-category list."
   end
 end


### PR DESCRIPTION
## Description
This pull request updates the logic for displaying and enabling name type selection and editing in the name forms and tabs. The changes refine permission checks and option lists to better handle cases for users with limited permissions, especially around common names.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
