### PR TITLE
NSL-5896: Implement change_name permissions for draft instances and a…

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -205,6 +205,13 @@ class Ability
     can "names/typeaheads/for_unpub_cit", "index"
     can "names", "tab_instances_profile_v2"
     can "references", "tab_new_instance"
+
+    # NOTES Change name permissions
+    can :change_name, Instance do |instance|
+      instance.draft? && instance.reference.products.pluck(:name).any?(selected_product(user)&.name.to_s)
+    end
+    can "instances", "change_name"
+    can "instances", "typeahead_for_change_name"
   end
 
   def profile_editor(session_user)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -210,8 +210,8 @@ class Ability
     can :change_name, Instance do |instance|
       instance.draft? && instance.reference.products.pluck(:name).any?(selected_product(user)&.name.to_s)
     end
-    can "instances", "change_name"
-    can "instances", "typeahead_for_change_name"
+    can "instances/change_name", "update"
+    can "instances/change_name", "typeahead"
   end
 
   def profile_editor(session_user)

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -88,7 +88,8 @@ class Instance < ApplicationRecord
                 :consider_taxo,
                 :concept_warning_bypassed,
                 :multiple_primary_override,
-                :duplicate_instance_override
+                :duplicate_instance_override,
+                :name_change_permitted
 
   SEARCH_LIMIT = 50
   MULTIPLE_PRIMARY_WARNING = "Saving this instance would result in multiple primary instances for the same name."
@@ -523,8 +524,10 @@ class Instance < ApplicationRecord
   end
 
   def name_id_must_not_change
+    return if name_change_permitted
     errors.add(:base, "You cannot use a different name.") if name_id_changed?
   end
+
 
   # A standalone instance with no dependents can change reference.
   def standalone_reference_id_can_change_if_no_dependents

--- a/app/models/instance/as_typeahead/for_change_name.rb
+++ b/app/models/instance/as_typeahead/for_change_name.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+# Returns names matching the search term, filtered to the same name_type and
+# name_rank as the instance's current name. Used when changing the name on a
+# draft standalone instance.
+class Instance::AsTypeahead::ForChangeName
+  attr_reader :suggestions
+
+  SEARCH_LIMIT = 50
+
+  def initialize(term:, name_type_id:, name_rank_id:, exclude_name_id:)
+    @suggestions = term.blank? ? [] : query(term, name_type_id, name_rank_id, exclude_name_id)
+  end
+
+  private
+
+  def query(term, name_type_id, name_rank_id, exclude_name_id)
+    Name.not_a_duplicate
+        .where("lower(full_name) like lower(?)", term.tr("*", "%") + "%")
+        .where(name_type_id: name_type_id, name_rank_id: name_rank_id)
+        .where.not(id: exclude_name_id)
+        .joins(:name_rank)
+        .order("name_rank.sort_order, lower(full_name)")
+        .limit(SEARCH_LIMIT)
+        .map { |n| { value: n.full_name, id: n.id } }
+  end
+end

--- a/app/services/instances/change_name_service.rb
+++ b/app/services/instances/change_name_service.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+module Instances
+  class ChangeNameService < BaseService
+    def initialize(instance:, new_name_id:, username:)
+      super({})
+      @instance = instance
+      @new_name_id = new_name_id.to_i
+      @username = username
+    end
+
+    def execute
+      new_name = Name.find(@new_name_id)
+
+      if synonym_name_ids.include?(@new_name_id)
+        return errors.add(:base, "#{new_name.full_name} is listed as a synonym of this instance.")
+      end
+
+      unless new_name.name_type_id == @instance.name.name_type_id &&
+             new_name.name_rank_id == @instance.name.name_rank_id
+        return errors.add(:base, "The selected name must be the same type and rank as the current name.")
+      end
+
+      @instance.name_change_permitted = true
+      @instance.name_id = @new_name_id
+      @instance.updated_by = @username
+      @instance.save
+      errors.merge!(@instance.errors) if @instance.errors.any?
+    end
+
+    private
+
+    def synonym_name_ids
+      Instance.where(cited_by_id: @instance.id).where.not(cites_id: nil).pluck(:name_id)
+    end
+  end
+end

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,4 @@
-- :date: 01-05-2026
+- :date: 04-05-2026
   :jira_id: '5896'
   :description: |-
     Ability and service object changes to support the change name workflow for draft instances

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 01-05-2026
+  :jira_id: '5896'
+  :description: |-
+    Ability and service object changes to support the change name workflow for draft instances
+- :date: 01-05-2026
   :jira_id: ''
   :description: |-
     Chore: Add vim to the editor development Dockerfile for easier debugging and testing in the container

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.2.12
+appversion=5.1.2.13

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -843,12 +843,12 @@ RSpec.describe Ability, type: :model do
       allow(product).to receive(:is_name_index?).and_return(false)
     end
 
-    it "can access instances change_name action" do
-      expect(subject.can?("instances", "change_name")).to eq true
+    it "can access instances/change_name update action" do
+      expect(subject.can?("instances/change_name", "update")).to eq true
     end
 
-    it "can access instances typeahead_for_change_name action" do
-      expect(subject.can?("instances", "typeahead_for_change_name")).to eq true
+    it "can access instances/change_name typeahead action" do
+      expect(subject.can?("instances/change_name", "typeahead")).to eq true
     end
 
     context "with a draft instance belonging to the user product" do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -834,6 +834,68 @@ RSpec.describe Ability, type: :model do
     end
   end
 
+  describe "#draft_editor role - change_name permissions" do
+    let(:product) { create(:product, is_name_index: false) }
+
+    before do
+      allow(session_user).to receive(:with_role?).with("draft-editor").and_return(true)
+      allow(session_user).to receive(:product_from_context).and_return(product)
+      allow(product).to receive(:is_name_index?).and_return(false)
+    end
+
+    it "can access instances change_name action" do
+      expect(subject.can?("instances", "change_name")).to eq true
+    end
+
+    it "can access instances typeahead_for_change_name action" do
+      expect(subject.can?("instances", "typeahead_for_change_name")).to eq true
+    end
+
+    context "with a draft instance belonging to the user product" do
+      let(:instance) { create(:instance, draft: true) }
+
+      before do
+        products_collection = double("products_collection")
+        allow(products_collection).to receive(:pluck).with(:name).and_return([product.name])
+        allow(instance).to receive_message_chain(:reference, :products).and_return(products_collection)
+        allow(session_user).to receive(:product_from_context).and_return(product)
+      end
+
+      it "can :change_name on a draft instance whose reference belongs to the user product" do
+        expect(subject.can?(:change_name, instance)).to eq true
+      end
+    end
+
+    context "with a draft instance belonging to a different product" do
+      let(:instance) { create(:instance, draft: true) }
+      let(:other_product) { create(:product, name: "OTHER") }
+
+      before do
+        products_collection = double("products_collection")
+        allow(products_collection).to receive(:pluck).with(:name).and_return([other_product.name])
+        allow(instance).to receive_message_chain(:reference, :products).and_return(products_collection)
+      end
+
+      it "cannot :change_name on a draft instance whose reference belongs to a different product" do
+        expect(subject.can?(:change_name, instance)).to eq false
+      end
+    end
+
+    context "with a non-draft instance" do
+      let(:instance) { create(:instance, draft: false) }
+
+      before do
+        products_collection = double("products_collection")
+        allow(products_collection).to receive(:pluck).with(:name).and_return([product.name])
+        allow(instance).to receive_message_chain(:reference, :products).and_return(products_collection)
+      end
+
+      it "cannot :change_name on a non-draft instance" do
+        expect(subject.can?(:change_name, instance)).to eq false
+      end
+    end
+  end
+
   describe "#profile_editor role" do
     let(:product) { create(:product, is_name_index: false)}
 

--- a/spec/models/instance/as_typeahead/for_change_name_spec.rb
+++ b/spec/models/instance/as_typeahead/for_change_name_spec.rb
@@ -1,0 +1,146 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Instance::AsTypeahead::ForChangeName, type: :model do
+  let(:name_rank) { create(:name_rank) }
+  let(:name_type) { create(:name_type) }
+  let(:name) do
+    create(:name, full_name: "Acacia dealbata", name_type: name_type, name_rank: name_rank, duplicate_of_id: nil)
+  end
+
+  describe "#suggestions" do
+    context "when term is blank" do
+      it "returns an empty array" do
+        result = described_class.new(
+          term: "",
+          name_type_id: name_type.id,
+          name_rank_id: name_rank.id,
+          exclude_name_id: 0
+        )
+        expect(result.suggestions).to eq([])
+      end
+
+      it "returns an empty array for nil term" do
+        result = described_class.new(
+          term: nil,
+          name_type_id: name_type.id,
+          name_rank_id: name_rank.id,
+          exclude_name_id: 0
+        )
+        expect(result.suggestions).to eq([])
+      end
+    end
+
+    context "when term matches a name" do
+      before { name }
+
+      it "returns matching names as value/id hashes" do
+        result = described_class.new(
+          term: "Acacia",
+          name_type_id: name_type.id,
+          name_rank_id: name_rank.id,
+          exclude_name_id: 0
+        )
+        expect(result.suggestions).to include({ value: "Acacia dealbata", id: name.id })
+      end
+
+      it "is case-insensitive" do
+        result = described_class.new(
+          term: "acacia",
+          name_type_id: name_type.id,
+          name_rank_id: name_rank.id,
+          exclude_name_id: 0
+        )
+        expect(result.suggestions).to include({ value: "Acacia dealbata", id: name.id })
+      end
+    end
+
+    context "when term does not match" do
+      before { name }
+
+      it "returns an empty array" do
+        result = described_class.new(
+          term: "Banksia",
+          name_type_id: name_type.id,
+          name_rank_id: name_rank.id,
+          exclude_name_id: 0
+        )
+        expect(result.suggestions).to eq([])
+      end
+    end
+
+    context "when name has a different name_type_id" do
+      let(:other_name_type) { create(:name_type) }
+      let!(:other_name) do
+        create(:name, full_name: "Acacia other", name_type: other_name_type, name_rank: name_rank, duplicate_of_id: nil)
+      end
+
+      before { name }
+
+      it "excludes names of different type" do
+        result = described_class.new(
+          term: "Acacia",
+          name_type_id: name_type.id,
+          name_rank_id: name_rank.id,
+          exclude_name_id: 0
+        )
+        ids = result.suggestions.map { |s| s[:id] }
+        expect(ids).not_to include(other_name.id)
+      end
+    end
+
+    context "when name has a different name_rank_id" do
+      let(:other_rank) { create(:name_rank) }
+      let!(:other_name) do
+        create(:name, full_name: "Acacia different rank", name_type: name_type, name_rank: other_rank, duplicate_of_id: nil)
+      end
+
+      before { name }
+
+      it "excludes names of different rank" do
+        result = described_class.new(
+          term: "Acacia",
+          name_type_id: name_type.id,
+          name_rank_id: name_rank.id,
+          exclude_name_id: 0
+        )
+        ids = result.suggestions.map { |s| s[:id] }
+        expect(ids).not_to include(other_name.id)
+      end
+    end
+
+    context "when name is excluded by exclude_name_id" do
+      before { name }
+
+      it "excludes the current name" do
+        result = described_class.new(
+          term: "Acacia",
+          name_type_id: name_type.id,
+          name_rank_id: name_rank.id,
+          exclude_name_id: name.id
+        )
+        ids = result.suggestions.map { |s| s[:id] }
+        expect(ids).not_to include(name.id)
+      end
+    end
+
+    context "when name is a duplicate" do
+      before do
+        duplicate_name = create(:name, full_name: "Acacia dup", name_type: name_type, name_rank: name_rank, duplicate_of_id: nil)
+        name.update_column(:duplicate_of_id, duplicate_name.id)
+      end
+
+      it "excludes duplicate names" do
+        result = described_class.new(
+          term: "Acacia",
+          name_type_id: name_type.id,
+          name_rank_id: name_rank.id,
+          exclude_name_id: 0
+        )
+        ids = result.suggestions.map { |s| s[:id] }
+        expect(ids).not_to include(name.id)
+      end
+    end
+  end
+end

--- a/spec/services/instances/change_name_service_spec.rb
+++ b/spec/services/instances/change_name_service_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+describe Instances::ChangeNameService do
+  let(:name_rank) { create(:name_rank) }
+  let(:name_type) { create(:name_type) }
+  let(:current_name) { create(:name, name_type:, name_rank:) }
+  let(:draft_instance) { create(:instance, name: current_name, draft: true) }
+  let(:username) { "test_editor" }
+
+  subject(:service) do
+    described_class.new(
+      instance: draft_instance,
+      new_name_id: new_name.id,
+      username: username
+    )
+  end
+
+  describe "#execute" do
+    context "when the new name matches the current type and rank" do
+      let(:new_name) { create(:name, name_type:, name_rank:) }
+
+      it "changes the instance name in the database" do
+        service.execute
+        expect(draft_instance.reload.name_id).to eq(new_name.id)
+      end
+
+      it "records the user who made the change" do
+        service.execute
+        expect(draft_instance.reload.updated_by).to eq(username)
+      end
+
+      it "succeeds without errors" do
+        service.execute
+        expect(service.errors).to be_empty
+      end
+    end
+
+    context "when the new name is already listed as a synonym" do
+      let(:new_name) { create(:name, name_type:, name_rank:) }
+
+      before do
+        cites = build(:instance, name: new_name, reference: draft_instance.reference)
+        cites.save(validate: false)
+        syn = build(:instance, cited_by_id: draft_instance.id, cites_id: cites.id,
+                               name: new_name, reference: draft_instance.reference)
+        syn.save(validate: false)
+      end
+
+      it "does not change the instance name" do
+        expect { service.execute }.not_to change { draft_instance.reload.name_id }
+      end
+
+      it "reports an error" do
+        service.execute
+        expect(service.errors).not_to be_empty
+      end
+    end
+
+    context "when the new name has a different type" do
+      let(:new_name) { create(:name, name_type: create(:name_type), name_rank:) }
+
+      it "does not change the instance name" do
+        expect { service.execute }.not_to change { draft_instance.reload.name_id }
+      end
+
+      it "reports an error" do
+        service.execute
+        expect(service.errors).not_to be_empty
+      end
+    end
+
+    context "when the new name has a different rank" do
+      let(:new_name) { create(:name, name_type:, name_rank: create(:name_rank)) }
+
+      it "does not change the instance name" do
+        expect { service.execute }.not_to change { draft_instance.reload.name_id }
+      end
+
+      it "reports an error" do
+        service.execute
+        expect(service.errors).not_to be_empty
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
This pull request adds new permissions for the "draft_editor" role to allow changing the name of draft instances, along with comprehensive tests to ensure these permissions are correctly enforced. The main changes include updating the authorization logic and expanding the test suite to cover various scenarios for the new permission.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [ ] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
