### PR TITLE
NSL-5896: Implement ChangeNameController with update and typeahead ac…

### DIFF
--- a/app/controllers/instances/change_name_controller.rb
+++ b/app/controllers/instances/change_name_controller.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+class Instances::ChangeNameController < ApplicationController
+  before_action :find_instance
+
+  def update
+    new_name_id = params[:instance]&.fetch(:name_id, nil)
+    if new_name_id.blank?
+      @message = "Please select a name."
+      return render("instances/change_name_error", status: :unprocessable_content)
+    end
+    service = Instances::ChangeNameService.call(
+      instance: @instance,
+      new_name_id: new_name_id.to_i,
+      username: current_user.username
+    )
+    if service.errors.any?
+      @message = service.errors.full_messages.join(", ")
+      return render("instances/change_name_error", status: :unprocessable_content)
+    end
+    @message = "Name updated"
+    render("instances/change_name")
+  rescue StandardError => e
+    @message = e.to_s
+    render("instances/change_name_error", status: :unprocessable_content)
+  end
+
+  def typeahead
+    typeahead = Instance::AsTypeahead::ForChangeName.new(
+      term: params[:term],
+      name_type_id: @instance.name.name_type_id,
+      name_rank_id: @instance.name.name_rank_id,
+      exclude_name_id: @instance.name_id,
+    )
+    render(json: typeahead.suggestions)
+  end
+
+  private
+
+  def find_instance
+    @instance = Instance.find(params[:instance_id])
+  end
+end

--- a/app/views/instances/change_name.js.erb
+++ b/app/views/instances/change_name.js.erb
@@ -1,0 +1,3 @@
+$('.message-container').html('');
+$('.error-container').html('');
+$('#search-result-details-info-message-container').html('<%= escape_javascript(@message) %>');

--- a/app/views/instances/change_name_error.js.erb
+++ b/app/views/instances/change_name_error.js.erb
@@ -1,0 +1,3 @@
+$('.message-container').html('');
+$('.error-container').html('');
+$('#search-result-details-error-message-container').html('<%= escape_javascript(@message) %>');

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,6 +1,10 @@
 - :date: 04-05-2026
   :jira_id: '5896'
   :description: |-
+    Change name controller and js template changes to support the change name workflow for draft instances
+- :date: 04-05-2026
+  :jira_id: '5896'
+  :description: |-
     Ability and service object changes to support the change name workflow for draft instances
 - :date: 01-05-2026
   :jira_id: ''

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -121,7 +121,11 @@ Rails.application.routes.draw do
         as: "copy_standalone", to: "instances#copy_standalone", via: :post
   match "instances/:id/standalone/copy_for_profile_v2",
         as: "copy_for_profile_v2", to: "instances#copy_for_profile_v2", via: :post
-  resources :instances, only: %i[new create update destroy]
+  resources :instances, only: %i[new create update destroy] do
+    resource :name, only: [:update], controller: "instances/change_name" do
+      get :typeahead
+    end
+  end
   match "instances/:id",
         as: "instance_show",
         to: "instances#show",

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.2.13
+appversion=5.1.2.14

--- a/spec/controllers/instances/change_name_controller_spec.rb
+++ b/spec/controllers/instances/change_name_controller_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Instances::ChangeNameController, type: :controller do
+  let(:session_user) { FactoryBot.create(:session_user, groups: ["login"]) }
+  let(:name_type) { FactoryBot.create(:name_type) }
+  let(:name_rank) { FactoryBot.create(:name_rank) }
+  let(:current_name) { FactoryBot.create(:name, name_type:, name_rank:) }
+  let(:instance) { FactoryBot.create(:instance, name: current_name, draft: true) }
+
+  before do
+    emulate_user_login(session_user)
+    allow(controller).to receive(:can?).with("instances/change_name", "update").and_return(true)
+    allow(controller).to receive(:can?).with("instances/change_name", "typeahead").and_return(true)
+    allow(controller).to receive(:authorise).and_return(true)
+  end
+
+  describe "PATCH #update" do
+    context "when no name is selected" do
+      it "returns an error response without changing the name" do
+        expect {
+          patch :update, params: { instance_id: instance.id, instance: { name_id: "" } }, xhr: true
+        }.not_to change { instance.reload.name_id }
+
+        expect(response).to render_template("instances/change_name_error")
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    context "when the new name has the same type and rank" do
+      let(:new_name) { FactoryBot.create(:name, name_type:, name_rank:) }
+
+      it "updates the instance name and renders the success template" do
+        patch :update, params: { instance_id: instance.id, instance: { name_id: new_name.id.to_s } }, xhr: true
+
+        expect(instance.reload.name_id).to eq(new_name.id)
+        expect(response).to render_template("instances/change_name")
+      end
+    end
+
+    context "when the new name has a different type or rank" do
+      let(:new_name) { FactoryBot.create(:name) }
+
+      it "returns an error response without changing the name" do
+        expect {
+          patch :update, params: { instance_id: instance.id, instance: { name_id: new_name.id.to_s } }, xhr: true
+        }.not_to change { instance.reload.name_id }
+
+        expect(response).to render_template("instances/change_name_error")
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    context "when the selected name is already a synonym of the instance" do
+      let(:synonym_name) { FactoryBot.create(:name, name_type:, name_rank:) }
+
+      before do
+        cites = build(:instance, name: synonym_name, reference: instance.reference)
+        cites.save(validate: false)
+        syn = build(:instance, cited_by_id: instance.id, cites_id: cites.id,
+                               name: synonym_name, reference: instance.reference)
+        syn.save(validate: false)
+      end
+
+      it "returns an error response without changing the name" do
+        expect {
+          patch :update, params: { instance_id: instance.id, instance: { name_id: synonym_name.id.to_s } }, xhr: true
+        }.not_to change { instance.reload.name_id }
+
+        expect(response).to render_template("instances/change_name_error")
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+
+  describe "GET #typeahead" do
+    def result_ids
+      JSON.parse(response.body).map { |r| r["id"] }
+    end
+
+    context "when searching with a matching term" do
+      let(:matching_name) { FactoryBot.create(:name, name_type:, name_rank:, full_name: "Acacia dealbata") }
+
+      before { matching_name }
+
+      it "returns names with the same type and rank" do
+        get :typeahead, params: { instance_id: instance.id, term: "Acacia" }
+        expect(result_ids).to include(matching_name.id)
+      end
+
+      it "excludes names with a different rank" do
+        other_rank_name = FactoryBot.create(:name, name_type:, name_rank: FactoryBot.create(:name_rank), full_name: "Acacia aneura")
+        get :typeahead, params: { instance_id: instance.id, term: "Acacia" }
+        expect(result_ids).not_to include(other_rank_name.id)
+      end
+
+      it "excludes the instance's current name" do
+        # current_name has full_name "Sample Full name" — create another same-type name to confirm
+        # only the current name is excluded, not all matches
+        other_name = FactoryBot.create(:name, name_type:, name_rank:, full_name: "Sample Other name")
+        get :typeahead, params: { instance_id: instance.id, term: "Sample" }
+        expect(result_ids).not_to include(current_name.id)
+        expect(result_ids).to include(other_name.id)
+      end
+    end
+
+    context "when the term is blank" do
+      it "returns an empty array" do
+        get :typeahead, params: { instance_id: instance.id, term: "" }
+        expect(JSON.parse(response.body)).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
This pull request introduces a new feature that allows updating the name associated with an `Instance` through a dedicated controller and endpoint. It also adds typeahead support for selecting valid names and includes comprehensive tests for the new functionality. The main changes are as follows:

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [ ] Manual testing

## Related Issues
<!-- Link to related issues (if any) -->

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
