### PR TITLE
Nsl 5896 allow authorised user to change name for draft instance UI

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -59,6 +59,7 @@ import "typeaheads_for_instance_reference_profile_v2";
 import "typeaheads_for_instance_reference_excluding_current";
 import "typeaheads_for_instance_synonymy";
 import "typeaheads_for_instance_product_item_config";
+import "typeaheads_for_instance_change_name";
 
 import "typeaheads_for_loader_batch_default_reference";
 import "typeaheads_for_loader_name_parent";

--- a/app/javascript/typeaheads/for_instance/change_name.js
+++ b/app/javascript/typeaheads/for_instance/change_name.js
@@ -1,0 +1,30 @@
+
+function setUpInstanceNameChange(instanceId) {
+  var changeNameBloodhound = new Bloodhound({
+    datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
+    queryTokenizer: Bloodhound.tokenizers.whitespace,
+    remote: {
+      url: window.relative_url_root + '/instances/' + instanceId + '/name/typeahead?term=%QUERY',
+      wildcard: '%QUERY'
+    },
+    limit: 50
+  });
+  changeNameBloodhound.initialize();
+
+  $('#instance-name-change-typeahead').typeahead(
+    { highlight: true },
+    { name: 'name-change', displayKey: 'value', source: changeNameBloodhound.ttAdapter() }
+  )
+  .on('typeahead:selected', function($e, datum) {
+    $('#instance-change-name-id').val(datum.id);
+  })
+  .on('typeahead:autocompleted', function($e, datum) {
+    $('#instance-change-name-id').val(datum.id);
+  })
+  .on('typeahead:closed', function($e, datum) {
+    // NOOP: cannot distinguish tabbing through vs emptying vs typing text.
+    // Users must select or autocomplete.
+  });
+}
+
+window.setUpInstanceNameChange = setUpInstanceNameChange;

--- a/app/views/instances/_form_change_name.html.erb
+++ b/app/views/instances/_form_change_name.html.erb
@@ -1,0 +1,27 @@
+<%= divider %>
+Change the name for this draft instance.
+<br>
+<br>
+<%= form_for(@instance,
+             url: instance_name_path(@instance),
+             html: { id: "change-name-form", method: :patch, remote: true }) do |f| %>
+  <input id="instance-name-change-typeahead"
+         name="instance[name_typeahead]"
+         class="typeahead form-control"
+         placeholder="<%= @instance.name.try('full_name') %>"
+         tabindex="<%= increment_tab_index %>"
+         title="Enter a name. Must be same type and rank as the current name."
+         type="text"
+         value="<%= @instance.name.try('full_name') %>"/>
+  <%= hidden_field_tag "instance[name_id]", "", id: "instance-change-name-id" %>
+  <script>setUpInstanceNameChange(<%= @instance.id %>);</script>
+  <br>
+  <%= f.submit "Change Name",
+               class: "btn btn-primary pull-right no-right-margin",
+               title: "Save changed name.",
+               tabindex: increment_tab_index %>
+  <br>
+  <br>
+  <div id="change-name-info-message-container" class="message-container"></div>
+  <div id="change-name-error-message-container" class="message-container error-container"></div>
+<% end %>

--- a/app/views/instances/_form_change_name.html.erb
+++ b/app/views/instances/_form_change_name.html.erb
@@ -1,7 +1,5 @@
-<%= divider %>
-Change the name for this draft instance.
-<br>
-<br>
+<br/>
+<p>Change the name for this draft instance.</p>
 <%= form_for(@instance,
              url: instance_name_path(@instance),
              html: { id: "change-name-form", method: :patch, remote: true }) do |f| %>
@@ -15,13 +13,14 @@ Change the name for this draft instance.
          value="<%= @instance.name.try('full_name') %>"/>
   <%= hidden_field_tag "instance[name_id]", "", id: "instance-change-name-id" %>
   <script>setUpInstanceNameChange(<%= @instance.id %>);</script>
-  <br>
+  <div id="change-name-info-message-container" class="message-container"></div>
+  <div id="change-name-error-message-container" class="message-container error-container"></div>
+  <div id="change-name-refresh-container"></div>
   <%= f.submit "Change Name",
                class: "btn btn-primary pull-right no-right-margin",
                title: "Save changed name.",
+               style: "padding: 0 10px",
                tabindex: increment_tab_index %>
-  <br>
-  <br>
-  <div id="change-name-info-message-container" class="message-container"></div>
-  <div id="change-name-error-message-container" class="message-container error-container"></div>
 <% end %>
+<br/>
+<%= divider %>

--- a/app/views/instances/_form_update_standalone.html.erb
+++ b/app/views/instances/_form_update_standalone.html.erb
@@ -14,19 +14,20 @@
                 search_path(query_string:
                             "id: #{@instance.name_id} show-instances:",
                             query_target: "name"),
+                id: "instance-name-link",
                 title: "Name search for instances") %>
     <br>
     appears in<span class="red">*</span>
     <% if  @instance.update_reference_allowed? %>
             <% focus_taken = true %>
             <input id="instance-reference-typeahead"
-                   name="instance[reference_typeahead]"   
+                   name="instance[reference_typeahead]"
                    class="typeahead form-control give-me-focus"
                    placeholder="Reference"
                    title="Enter a reference citation.  This is a reference typeahead - enter any fragments of the reference citation in any order to narrow the list."
                    required="true"
                    tabindex="<%= increment_tab_index %>"
-                   type="text" 
+                   type="text"
                    value="<%= @instance.reference.try('citation') %>"/>
         <%= f.hidden_field :reference_id %>
         <script> setUpInstanceReference(); </script>
@@ -34,8 +35,8 @@
       <% focus_taken = false %>
       <%= show_field_as_linked_lookup('',@instance.reference,'citation', search_path(query_string: %Q(id:#{@instance.reference_id}),query_target: 'reference'),'to the reference') %>
     <% end %>
- 
-    as a<span class="red">*</span> 
+
+    as a<span class="red">*</span>
     <br>
     <%= f.select(:instance_type_id, InstanceType.standalone_options,{include_blank: true},
                            {value: @instance.instance_type_id,data:{update_url: instance_path},

--- a/app/views/instances/change_name.js.erb
+++ b/app/views/instances/change_name.js.erb
@@ -3,3 +3,4 @@ $('#change-name-info-message-container').html('<%= escape_javascript(@message) %
 $('#instance-name-link').text('<%= escape_javascript(@instance.name.full_name) %>');
 $('#instance-name-change-typeahead').typeahead('val', '<%= escape_javascript(@instance.name.full_name) %>');
 $('#instance-change-name-id').val('');
+$('#change-name-refresh-container').html('<a href="<%= escape_javascript(search_path(query_target: "name", query_string: "id: #{@instance.name_id} show-instances:")) %>" title="Name Change Successful" class="btn btn-success btn-sm">Refresh</a>');

--- a/app/views/instances/change_name.js.erb
+++ b/app/views/instances/change_name.js.erb
@@ -1,3 +1,5 @@
-$('.message-container').html('');
-$('.error-container').html('');
-$('#search-result-details-info-message-container').html('<%= escape_javascript(@message) %>');
+$('#change-name-error-message-container').html('');
+$('#change-name-info-message-container').html('<%= escape_javascript(@message) %>');
+$('#instance-name-link').text('<%= escape_javascript(@instance.name.full_name) %>');
+$('#instance-name-change-typeahead').typeahead('val', '<%= escape_javascript(@instance.name.full_name) %>');
+$('#instance-change-name-id').val('');

--- a/app/views/instances/change_name_error.js.erb
+++ b/app/views/instances/change_name_error.js.erb
@@ -1,3 +1,2 @@
-$('.message-container').html('');
-$('.error-container').html('');
-$('#search-result-details-error-message-container').html('<%= escape_javascript(@message) %>');
+$('#change-name-info-message-container').html('');
+$('#change-name-error-message-container').html('<%= escape_javascript(@message) %>');

--- a/app/views/instances/tabs/_show_standalone.html.erb
+++ b/app/views/instances/tabs/_show_standalone.html.erb
@@ -5,6 +5,10 @@
             class: 'name') %>
 <%= " [#{@instance.name.try('name_status').try('name_without_brackets')}]" if @instance.try('name').try('name_status').try('legitimate?') %>
 
+<% if @instance.draft? && can?(:change_name, @instance) %>
+    <%= render 'form_change_name'  %>
+<% end %>
+
 <% if @instance.name.accepted_concept? || @instance.name.excluded_concept? %>
     <%= render(partial: 'instances/taxo/details/widgets', locals: {instance: @instance}) %>
 <% end %>

--- a/app/views/instances/tabs/_show_standalone.html.erb
+++ b/app/views/instances/tabs/_show_standalone.html.erb
@@ -5,8 +5,15 @@
             class: 'name') %>
 <%= " [#{@instance.name.try('name_status').try('name_without_brackets')}]" if @instance.try('name').try('name_status').try('legitimate?') %>
 
-<% if @instance.draft? && can?(:change_name, @instance) %>
-    <%= render 'form_change_name'  %>
+<% if @instance.draft? && can?(:change_name, @instance) && local_assigns.fetch(:with_name_change, nil) == true %>
+  <%= link_to "change name",
+              "#",
+              onclick: "$('#change-name-form-container').toggle(); return false;",
+              title: "Show or hide the change name form",
+              class: "small" %>
+  <div id="change-name-form-container" style="display: none">
+    <%= render 'form_change_name' %>
+  </div>
 <% end %>
 
 <% if @instance.name.accepted_concept? || @instance.name.excluded_concept? %>

--- a/app/views/instances/tabs/_tab_edit_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_edit_profile_v2.html.erb
@@ -8,7 +8,7 @@
   <div id="search-result-details-error-message-container-2" class="error-container"></div>
   <div id="search-result-details-error-message-container-3" class="error-container"></div>
 
-  <%= render partial: "instances/tabs/show_standalone"%>
+  <%= render partial: "instances/tabs/show_standalone", locals: { with_name_change: true } %>
 
   <%= divider %>
   <% if @instance.allow_delete? %>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 05-05-2026
+  :jira_id: '5896'
+  :description: |-
+    UI integration for the change name workflow for draft instances
 - :date: 04-05-2026
   :jira_id: '5896'
   :description: |-

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -64,6 +64,7 @@ pin "typeaheads_for_instance_reference_profile_v2", to: "typeaheads/for_instance
 pin "typeaheads_for_instance_reference_excluding_current", to: "typeaheads/for_instance/reference_excluding_current.js"
 pin "typeaheads_for_instance_synonymy", to: "typeaheads/for_instance/synonymy.js"
 pin "typeaheads_for_instance_product_item_config", to: "typeaheads/for_instance/name_for_product_item_config.js"
+pin "typeaheads_for_instance_change_name", to: "typeaheads/for_instance/change_name.js"
 
 pin "typeaheads_for_loader_batch_default_reference", to: "typeaheads/for_loader_batch/default_reference.js"
 pin "typeaheads_for_loader_name_parent", to: "typeaheads/for_loader_name/parent.js"

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.2.14
+appversion=5.1.2.15

--- a/spec/views/instances/tabs/tab_edit_profile_v2_spec.rb
+++ b/spec/views/instances/tabs/tab_edit_profile_v2_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "instances/tabs/_tab_edit_profile_v2.html.erb", type: :view do
-  let(:language) { Language.find_by!(iso6391code: "en") }
+  let(:language) { Language.find_or_create_by!(iso6391code: "en") { |l| l.iso6393code = "eng"; l.name = "English" } }
   let(:reference) { FactoryBot.create(:reference, language: language) }
   let(:instance_type) { FactoryBot.create(:instance_type, secondary_instance: false)}
   let(:instance) { FactoryBot.create(:instance, reference: reference) }

--- a/spec/views/instances/tabs/tab_edit_profile_v2_spec.rb
+++ b/spec/views/instances/tabs/tab_edit_profile_v2_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "instances/tabs/_tab_edit_profile_v2.html.erb", type: :view do
-  let(:language) { FactoryBot.create(:language, iso6391code: "en", iso6393code: "eng") }
+  let(:language) { Language.find_by!(iso6391code: "en") }
   let(:reference) { FactoryBot.create(:reference, language: language) }
   let(:instance_type) { FactoryBot.create(:instance_type, secondary_instance: false)}
   let(:instance) { FactoryBot.create(:instance, reference: reference) }
@@ -15,6 +15,7 @@ RSpec.describe "instances/tabs/_tab_edit_profile_v2.html.erb", type: :view do
   context "when the user can manage draft secondary references" do
     before do
       allow(view).to receive(:can?).with(:manage_draft_secondary_reference, instance).and_return(true)
+      allow(view).to receive(:can?).with(:change_name, instance).and_return(false)
       allow(ShardConfig).to receive(:classification_tree_key).and_return("some_value")
       allow(ShardConfig).to receive(:name_space).and_return("some_value")
       allow_any_instance_of(Name).to receive(:accepted_concept?).and_return(false)


### PR DESCRIPTION
## Description
This pull request introduces a new feature that allows users to change the name of a draft instance through a typeahead-enabled form. The main changes add the UI, JavaScript, and supporting infrastructure to display the change name form, handle typeahead name selection, and update the instance name asynchronously with appropriate feedback.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [ ] Bumped version
- [ ] Updated changelog (Please add an entry to the changelog for the current year)
