### PR TITLE
Fix 409 Conflict when replacing an instance on a draft tree

### DIFF
--- a/app/controllers/trees_controller.rb
+++ b/app/controllers/trees_controller.rb
@@ -90,7 +90,7 @@ class TreesController < ApplicationController
     authorize! :replace_placement, @working_draft,
       :message => "You are not authorized to replace a taxon in #{@working_draft.tree.name} draft"
     target = TreeVersionElement.find(move_name_params[:element_link])
-    parent = TreeVersionElement.find(move_name_params[:parent_element_link])
+    parent = resolve_parent_to_version(TreeVersionElement.find(move_name_params[:parent_element_link]), target.tree_version)
 
     profile = Tree::ProfileData.new(current_user, target.tree_version, {})
     profile.update_comment(move_name_params[:comment])
@@ -239,7 +239,7 @@ class TreesController < ApplicationController
     authorize! :update_tree_parent, @working_draft,
       :message => "Not authorized to update or delete #{@working_draft.tree.name} draft taxon parent"
     target = TreeVersionElement.find(update_parent_params[:element_link])
-    parent = TreeVersionElement.find(update_parent_params[:parent_element_link])
+    parent = resolve_parent_to_version(TreeVersionElement.find(update_parent_params[:parent_element_link]), target.tree_version)
     reparent = Tree::Workspace::Reparent.new(username: current_user.username,
                                              target: target,
                                              parent: parent)
@@ -277,7 +277,7 @@ class TreesController < ApplicationController
     render "trees/reports/run_cas_error", status: :forbidden
   rescue => e
     @message = e.to_s
-    render "trees/reports/run_cas_error", status: :bad_request 
+    render "trees/reports/run_cas_error", status: :bad_request
   end
 
   def show_diff
@@ -304,7 +304,7 @@ class TreesController < ApplicationController
     render "trees/reports/run_diff_error", status: :forbidden
   rescue => e
     @message = e.to_s
-    render "trees/reports/run_diff_error", status: :bad_request 
+    render "trees/reports/run_diff_error", status: :bad_request
   end
 
   def show_valrep
@@ -327,7 +327,7 @@ class TreesController < ApplicationController
     render "trees/reports/run_valrep_error", status: :forbidden
   rescue => e
     @message = e.to_s
-    render "trees/reports/run_valrep_error", status: :bad_request 
+    render "trees/reports/run_valrep_error", status: :bad_request
   end
 
   private
@@ -438,6 +438,11 @@ class TreesController < ApplicationController
 
   def remove_name_placement_params
     params.require(:remove_placement).permit(:taxon_uri, :delete)
+  end
+
+  def resolve_parent_to_version(parent, version)
+    return parent if parent.tree_version_id == version.id
+    version.tree_version_elements.find_by!(tree_element_id: parent.tree_element_id)
   end
 
   def find_tree

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,8 @@
+- :date: 14-May-2026
+  :jira_id: '214'
+  :jira_project: FLOR
+  :description: |-
+    Fixup the 409 conflict error when replacing a tree to a draft instance
 - :date: 05-05-2026
   :jira_id: '5896'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.0
+appversion=5.1.3.1

--- a/spec/controllers/trees_controller_spec.rb
+++ b/spec/controllers/trees_controller_spec.rb
@@ -1,0 +1,70 @@
+# spec/controllers/trees_controller_spec.rb
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe TreesController, type: :controller do
+  describe "#resolve_parent_to_version" do
+    let(:tree_element_id) { 52403480 }
+    let(:draft_version_id) { 52476019 }
+    let(:published_version_id) { 52386951 }
+
+    let(:draft_version) { instance_double(TreeVersion, id: draft_version_id) }
+
+    let(:same_version_parent) do
+      instance_double(TreeVersionElement,
+                      tree_version_id: draft_version_id,
+                      tree_element_id: tree_element_id)
+    end
+
+    let(:cross_version_parent) do
+      instance_double(TreeVersionElement,
+                      tree_version_id: published_version_id,
+                      tree_element_id: tree_element_id)
+    end
+
+    context "when parent is already in the target version" do
+      it "returns parent unchanged without querying the DB" do
+        expect(draft_version).not_to receive(:tree_version_elements)
+        result = controller.send(:resolve_parent_to_version, same_version_parent, draft_version)
+        expect(result).to eq(same_version_parent)
+      end
+    end
+
+    context "when parent is from a different (published) version" do
+      let(:tve_scope) { instance_double(ActiveRecord::Relation) }
+      let(:draft_parent) { instance_double(TreeVersionElement) }
+
+      before do
+        allow(draft_version).to receive(:tree_version_elements).and_return(tve_scope)
+        allow(tve_scope).to receive(:find_by!).with(tree_element_id: tree_element_id).and_return(draft_parent)
+      end
+
+      it "returns the equivalent TVE in the draft version" do
+        result = controller.send(:resolve_parent_to_version, cross_version_parent, draft_version)
+        expect(result).to eq(draft_parent)
+      end
+
+      it "looks up by tree_element_id in the target version" do
+        expect(tve_scope).to receive(:find_by!).with(tree_element_id: tree_element_id)
+        controller.send(:resolve_parent_to_version, cross_version_parent, draft_version)
+      end
+    end
+
+    context "when no matching element exists in the target version" do
+      let(:tve_scope) { instance_double(ActiveRecord::Relation) }
+
+      before do
+        allow(draft_version).to receive(:tree_version_elements).and_return(tve_scope)
+        allow(tve_scope).to receive(:find_by!).with(tree_element_id: tree_element_id)
+          .and_raise(ActiveRecord::RecordNotFound)
+      end
+
+      it "raises ActiveRecord::RecordNotFound" do
+        expect {
+          controller.send(:resolve_parent_to_version, cross_version_parent, draft_version)
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
When replacing an instance on a draft tree, the parent_element_link sent to the services pointed to the published version's tree element instead of the draft's, causing the error.

Added a `resolve_parent_to_version` helper that corrects the parent to the draft version before passing it to the service. Applied to both `replace_placement ` and `update_tree_parent`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
