### PR TITLE
Hide Tree tab from users without place_name permission

### DIFF
--- a/app/views/instances/tabs/_all_tab_headings.html.erb
+++ b/app/views/instances/tabs/_all_tab_headings.html.erb
@@ -157,21 +157,24 @@
   <% end %>
 
   <% if @tabs_to_offer.include?("tab_classification") && tab_available?(tabs_array, "tree") %>
-    <% if !Rails.configuration.try('multi_product_tabs_enabled') || current_product_from_context&.has_the_same_reference?(@instance) || current_registered_user.roles.blank? %>
-      <%= render(
-        partial: "instances/tabs/tab",
-        locals: {
-          first: false,
-          last: false,
-          this_tab: "tab_classification",
-          link_text: product_tab_text(:instance, "tree", "Tree"),
-          link_id: "instance-classification-tab",
-          link_title: "Tree placement",
-          tab_index: increment_tab_index,
-          prev_tab: "",
-          next_tab: ""
-        })
-      %>
+    <% if can?("instances", "tab_classification") %>
+      <% multi_product_tab_disabled = !Rails.configuration.try('multi_product_tabs_enabled') %>
+      <% if @working_draft && (can?(:place_name, @working_draft) && (multi_product_tab_disabled || current_product_from_context&.has_the_same_reference?(@instance) || current_registered_user.roles.blank? ))%>
+        <%= render(
+          partial: "instances/tabs/tab",
+          locals: {
+            first: false,
+            last: false,
+            this_tab: "tab_classification",
+            link_text: product_tab_text(:instance, "tree", "Tree"),
+            link_id: "instance-classification-tab",
+            link_title: "Tree placement",
+            tab_index: increment_tab_index,
+            prev_tab: "",
+            next_tab: ""
+          })
+        %>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,8 @@
+- :date: 14-Apr-2026
+  :jira_id: '226'
+  :jira_project: FLOR
+  :description: |-
+    Fixup the display of the Tree tab for user with/without tree permission
 - :date: 05-05-2026
   :jira_id: '5896'
   :description: |-

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,4 @@
-- :date: 14-Apr-2026
+- :date: 15-Apr-2026
   :jira_id: '226'
   :jira_project: FLOR
   :description: |-

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,21 +1,21 @@
-- :date: 15-Apr-2026
+- :date: 18-May-2026
   :jira_id: '226'
   :jira_project: FLOR
   :description: |-
     Fixup the display of the Tree tab for user with/without tree permission
-- :date: 05-05-2026
+- :date: 05-May-2026
   :jira_id: '5896'
   :description: |-
     UI integration for the change name workflow for draft instances
-- :date: 04-05-2026
+- :date: 04-May-2026
   :jira_id: '5896'
   :description: |-
     Change name controller and js template changes to support the change name workflow for draft instances
-- :date: 04-05-2026
+- :date: 04-May-2026
   :jira_id: '5896'
   :description: |-
     Ability and service object changes to support the change name workflow for draft instances
-- :date: 01-05-2026
+- :date: 01-May-2026
   :jira_id: ''
   :description: |-
     Chore: Add vim to the editor development Dockerfile for easier debugging and testing in the container

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.0
+appversion=5.1.3.1

--- a/spec/views/instances/tabs/tabs_all_tab_headings_partial_spec.rb
+++ b/spec/views/instances/tabs/tabs_all_tab_headings_partial_spec.rb
@@ -153,8 +153,13 @@ RSpec.describe("instances/tabs/_all_tab_headings.html.erb", type: :view) do
   end
 
   context "when 'tab_classification' is offered" do
+    let(:working_draft) { double("TreeVersion") }
+
     before do
       tabs_to_offer << "tab_classification"
+      assign(:working_draft, working_draft)
+      allow(view).to(receive(:can?).with("instances", "tab_classification").and_return(true))
+      allow(view).to(receive(:can?).with(:place_name, working_draft).and_return(true))
     end
 
     it "renders the 'Tree' tab" do
@@ -166,10 +171,14 @@ RSpec.describe("instances/tabs/_all_tab_headings.html.erb", type: :view) do
   context "when 'tab_classification' is offered with multi_product_tabs_enabled" do
     let(:user_with_roles) { FactoryBot.create(:user) }
     let(:user_without_roles) { FactoryBot.create(:user) }
+    let(:working_draft) { double("TreeVersion") }
 
     before do
       tabs_to_offer << "tab_classification"
+      assign(:working_draft, working_draft)
       allow(Rails.configuration).to(receive(:multi_product_tabs_enabled).and_return(true))
+      allow(view).to(receive(:can?).with("instances", "tab_classification").and_return(true))
+      allow(view).to(receive(:can?).with(:place_name, working_draft).and_return(true))
     end
 
     context "when current_product_from_context does not match the instance" do

--- a/test/integration/taxonomy/instances/tree_tab/tree_builder/foa/user_cannot_see_apc_tree_tab_test.rb
+++ b/test/integration/taxonomy/instances/tree_tab/tree_builder/foa/user_cannot_see_apc_tree_tab_test.rb
@@ -35,8 +35,7 @@ class TaxoInstanceTreeBuilderFoaCannotSeeAPCTreeTab < ActionController::TestCase
                    groups: ["login"],
                    draft: apc_draft})
     assert_response :success, "Tab request should be successful"
-    assert_match 'data-tab-name="tab_classification" href="#">Tree</a>',
-                    response.body, "Tab Classification should be in the response"
+    assert_no_match 'data-tab-name="tab_classification"', response.body, "Tree tab should not appear in nav for unauthorized user"
     assert_no_match '<form', response.body, 'Tab should not contain a form'
     assert_match 'You do not have permission to place names in this draft taxonomy.', response.body, 'User should see message about missing permissions'
   end

--- a/test/integration/taxonomy/instances/tree_tab/tree_publisher/apc/user_cannot_see_foa_tree_tab_test.rb
+++ b/test/integration/taxonomy/instances/tree_tab/tree_publisher/apc/user_cannot_see_foa_tree_tab_test.rb
@@ -35,8 +35,7 @@ class TaxoInstanceTreePublisherAPCCannotSeeFOATreeTab < ActionController::TestCa
                    groups: ["login"],
                    draft: foa_draft})
     assert_response :success, "Tree tab request should be successful"
-    assert_match 'data-tab-name="tab_classification" href="#">Tree</a>',
-                    response.body, "Tab Classification should be in the response"
+    assert_no_match 'data-tab-name="tab_classification"', response.body, "Tree tab should not appear in nav for unauthorized user"
     assert_no_match '<form', response.body, 'Tab should not contain a form'
     assert_match 'You do not have permission to place names in this draft taxonomy.', response.body, 'User should see message about missing permissions'
   end

--- a/test/integration/taxonomy/instances/tree_tab/tree_publisher/foa/user_cannot_see_apc_tree_tab_test.rb
+++ b/test/integration/taxonomy/instances/tree_tab/tree_publisher/foa/user_cannot_see_apc_tree_tab_test.rb
@@ -35,8 +35,7 @@ class TaxoInstanceTreePublisherFoaCannotSeeAPCTreeTab < ActionController::TestCa
                    groups: ["login"],
                    draft: apc_draft})
     assert_response :success, "Tab request should be successful"
-    assert_match 'data-tab-name="tab_classification" href="#">Tree</a>',
-                    response.body, "Tab Classification should be in the response"
+    assert_no_match 'data-tab-name="tab_classification"', response.body, "Tree tab should not appear in nav for unauthorized user"
     assert_no_match '<form', response.body, 'Tab should not contain a form'
     assert_match 'You do not have permission to place names in this draft taxonomy.', response.body, 'User should see message about missing permissions'
   end

--- a/test/integration/taxonomy/instances/tree_tab/tree_publisher/foa/user_cannot_see_foa_tree_tab_test.rb
+++ b/test/integration/taxonomy/instances/tree_tab/tree_publisher/foa/user_cannot_see_foa_tree_tab_test.rb
@@ -35,8 +35,7 @@ class TaxoInstanceTreePublisherFoaCannotSeeFoaTreeTab < ActionController::TestCa
                    groups: ["login"],
                    draft: foa_draft})
     assert_response :success, "Tree publisher tab request should be successful"
-    assert_match 'data-tab-name="tab_classification" href="#">Tree</a>',
-                  response.body, "Tab Classification should be in the response"
+    assert_no_match 'data-tab-name="tab_classification"', response.body, "Tree tab should not appear in nav for tree publisher"
     assert_no_match '<form', response.body, 'Tab should not contain a form'
   end
 end


### PR DESCRIPTION
## Summary
  - The Tree tab (`tab_classification`) is now hidden from users who lack permission to place names in the working draft, rather than showing the tab and displaying an error message inside it — this aligns tab visibility with actual access rights
  - Added a `can?(:place_name, @working_draft)` check alongside the existing `can?("instances", "tab_classification")` role check, so both conditions must be met for the tab to render

## Type of change
-  Bug fix — the Tree tab was visible to users who had no permission to use it, leaking UI affordances to unauthorized roles.

## Technical details
The previous condition relied on `current_registered_user.roles.blank?` and multi-product context matching to gate the tab, but did not account for the `place_name` permission on the specific working draft. A user could belong to the right product context but still lack the ability to place names in that draft, leaving them with a visible but unusable tab. The fix wraps the render in a `can?(:place_name, @working_draft)` guard so the tab only appears when the user can actually act on it.

## Test plan
  - [x] Log in as a tree builder for FOA — confirm the Tree tab is visible on an instance associated with an FOA working draft
  - [x] Log in as a tree builder for FOA — confirm the Tree tab is **not** visible on an instance associated with an APC working draft
  - [x] Log in as a tree publisher for APC — confirm the Tree tab is **not** visible on an instance associated with an FOA working draft
  - [x] Log in as a user with only `login` role — confirm the Tree tab does not appear at all in the instance tab navigation
  - [x] Confirm that users with correct permissions still see the tree placement form when clicking the Tree tab

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
