### PR TITLE
Fix SimpleMDE editor truncating pasted long text

### DIFF
--- a/app/assets/stylesheets/components/simple-mde-wysiwyg.css
+++ b/app/assets/stylesheets/components/simple-mde-wysiwyg.css
@@ -121,7 +121,10 @@
   height: 100px; /* Default height corresponding to 4 rows */
 }
 .CodeMirror {
-  min-height: 100px; /* Minimum height corresponding to 4 rows */
+  height: 200px;
+}
+.CodeMirror-scroll {
+  padding-bottom: 20px;
 }
 .message-container {
   margin-top: 5px;

--- a/app/javascript/simple_mde_wysiwyg.js
+++ b/app/javascript/simple_mde_wysiwyg.js
@@ -148,56 +148,9 @@ window.renderEditor = function(textarea) {
   // Adjust the CodeMirror instance
   var cm = simplemde.codemirror;
 
-  // Function to adjust height based on content
-  function adjustHeight() {
-    if (simplemde.isSideBySideActive()) {
-      return; // Skip height adjustment when in side-by-side mode
-    }
-    var contentHeight = cm.getScrollerElement().querySelector('.CodeMirror-sizer').scrollHeight;
-    var padding = 10; // Add some padding to ensure no clipping
-    var newHeight = contentHeight + padding;
-    var wrapperElement = cm.getWrapperElement();
-    var scrollerElement = cm.getScrollerElement();
-
-    wrapperElement.style.height = newHeight + 'px';
-    scrollerElement.style.maxHeight = newHeight + 'px';
-    scrollerElement.style.height = newHeight + 'px';
-
-    debug('===============================');
-    debug('wrapperElement.style.height:', wrapperElement.style.height);
-    debug('scrollerElement.style.maxHeight:', scrollerElement.style.maxHeight);
-    debug('scrollerElement.style.height:', scrollerElement.style.height);
-  }
-
-  // Initial height setting based on content
-  if (simplemde.value().trim() === "") {
-    // Set initial height to 4 rows when empty
-    var initialHeight = '100px'; // 100px corresponds to 4 rows
-    var wrapperElement = cm.getWrapperElement();
-    var scrollerElement = cm.getScrollerElement();
-
-    wrapperElement.style.height = initialHeight;
-    scrollerElement.style.maxHeight = initialHeight;
-    scrollerElement.style.height = initialHeight;
-
-    debug('===============================');
-    debug('Initial empty editor height settings');
-    debug('wrapperElement.style.height:', wrapperElement.style.height);
-    debug('scrollerElement.style.maxHeight:', scrollerElement.style.maxHeight);
-    debug('scrollerElement.style.height:', scrollerElement.style.height);
-  } else {
-    // Adjust height based on content
-    adjustHeight();
-  }
-
-  // Adjust height on content change
-  cm.on('change', adjustHeight);
-
-  // Adjust height when exiting side-by-side mode
-  cm.on('modeChange', function() {
-    if (!simplemde.isSideBySideActive()) {
-      setTimeout(adjustHeight, 0);
-    }
+  // After paste, scroll to the top so the beginning of the pasted content is visible
+  cm.on('paste', function() {
+    setTimeout(function() { cm.scrollTo(0, 0); }, 0);
   });
 
   debug('SimpleMDE initialized for', textarea.id, ':', simplemde);

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,9 @@
 - :date: 18-May-2026
+  :jira_id: '223'
+  :jira_project: FLOR
+  :description: |-
+    Fix the issue where pasting a long string in the profile item textarea was not showing all the content until the user saves the profile item
+- :date: 18-May-2026
   :jira_id: '226'
   :jira_project: FLOR
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.1
+appversion=5.1.3.2


### PR DESCRIPTION
# Summary
  - Replace dynamic auto-grow height logic with a fixed height so the editor scrolls rather than expanding infinitely — the previous `adjustHeight` approach measured the CodeMirror sizer synchronously on `change`, which caused stale scroll range calculations and made pasted content appear cut off
  - Add `padding-bottom` to `.CodeMirror-scroll` so the last line is reachable when scrolled to the bottom
  - Scroll the editor back to the top after a paste so the beginning of pasted content is immediately visible instead of the cursor position at the end

## Type of change
 - Bug fix

## Technical details
  The old `adjustHeight` function set `maxHeight` directly on `.CodeMirror-scroll`, which interfered with CodeMirror's internal sizer padding calculation — the element CodeMirror uses to determine how far you can scroll. Setting the height in CSS instead of JavaScript means CodeMirror reads the correct dimensions at initialisation time, so its scroll range covers all content from the start. Removing the JS-side height manipulation eliminates the race between CodeMirror's layout engine and our DOM writes.

## Test plan
  - [x] Open a profile text form and paste 20+ lines of text — all lines should be present (check the status bar line count)
  - [x] After pasting, the editor should scroll to the top showing line 1 of the pasted content
  - [x] Scroll to the bottom of the editor — the last pasted line should be fully visible, not clipped
  - [x] Type a short text manually — editor stays at 200px height (does not grow)
  - [x] Open a form that already has saved content — content loads correctly and is scrollable

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
