### PR TITLE
FLOR-237 - Fix refresh button after removing placement from tree

### DIFF
--- a/app/javascript/tree/refresh_tree_tab_refresh_page.js
+++ b/app/javascript/tree/refresh_tree_tab_refresh_page.js
@@ -1,14 +1,12 @@
 (function() {
-  var refreshTreeTab, refreshPage;
-
-  function refreshTreeTab(event) {
+  window.refreshTreeTab = function(event) {
     $('#instance-classification-tab').click();
     event.preventDefault();
     return false;
-  }
+  };
 
-  function refreshPage() {
-  location.reload();
-  }
+  window.refreshPage = function() {
+    location.reload();
+  };
 
 }).call(this);

--- a/app/views/trees/removed_placement.js.erb
+++ b/app/views/trees/removed_placement.js.erb
@@ -1,3 +1,4 @@
+$('#confirm_remove_placement').addClass('hidden');
 $('#remove-placement-error-message-container').addClass('hidden').html("");
 $('#remove-placement-message-container')
     .removeClass('hidden')

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,8 @@
+- :date: 19-May-2026
+  :jira_id: '237'
+  :jira_project: FLOR
+  :description: |-
+    Fixup the remove from tree button that seem to hang forever
 - :date: 18-May-2026
   :jira_id: '223'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.2
+appversion=5.1.3.3


### PR DESCRIPTION
## Summary
  - Fix the "refresh" button being non-functional after a successful "Remove from tree" operation — the refresh function wass unreachable from inline `onclick` handlers; both `refreshTreeTab` and `refreshPage` are now exposed on `window`
  - Hide the confirm removal button once the removal completes, preventing a stale action button from remaining visible in the UI

## Type of change
Fixup the broken refresh button on tree removal and the remove button not disappearing after removal

# Test plan
  - [x] Remove a name from the classification tree — verify the "refresh" button appears in the success message and clicking it reloads the tree tab without a console error
  - [x] After removal completes, confirm the confirm-removal button is no longer visible

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
