### PR TITLE
NSL-1319: Names and Instances: Allow copy of Instances from one Name to another Name

### DIFF
--- a/app/assets/stylesheets/components/old-application.css
+++ b/app/assets/stylesheets/components/old-application.css
@@ -294,6 +294,7 @@ tr.search-result.fresh td.main-content {
 }
 
 .message-container,
+.message-container a,
 .batch-message-container {
   margin-top: 1em;
   font-size: 13px;

--- a/app/assets/stylesheets/components/stylish.css
+++ b/app/assets/stylesheets/components/stylish.css
@@ -171,3 +171,7 @@ hr.dark {
   background-color: #e67e22;
   color: #fff;
 }
+
+.nowrap {
+  white-space: nowrap;
+}

--- a/app/controllers/concerns/name/copy_instances.rb
+++ b/app/controllers/concerns/name/copy_instances.rb
@@ -1,0 +1,16 @@
+module Name::CopyInstances
+  extend ActiveSupport::Concern
+
+  def copy_instances
+    raise "Please supply a target Name" if name_params[:target_name_id].blank?
+    raise "Please choose one or more instances" if name_params[:instance_ids_to_copy].compact_blank.blank?
+
+    @target_name = Name.find(name_params[:target_name_id])
+    @tally = @name.copy_standalone_instances(@target_name, name_params[:instance_ids_to_copy].compact_blank, current_user.username)
+    render "names/copy_instances/success"
+  rescue StandardError => e
+    @message = e.to_s
+    logger.error("Error in Name#copy_instances: #{@message}")
+    render "names/copy_instances/error"
+  end
+end

--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -22,11 +22,14 @@ require "open-uri"
 class NamesController < ApplicationController
   include OpenURI
   include Name::Typeaheads
+  include Name::CopyInstances
   # All text/html requests should go to the search page, except for rules.
   before_action :javascript_only, except: %i[rules refresh_children]
   before_action :find_name,
                 only: %i[show tab edit_as_category
-                         refresh refresh_children transfer_dependents]
+                         refresh refresh_children
+                         transfer_dependents
+                         copy_instances]
 
   # GET /names/1
   # GET /names/1.json
@@ -263,7 +266,9 @@ class NamesController < ApplicationController
                                  :name_element,
                                  :verbatim_rank,
                                  :published_year,
-                                 :changed_combination)
+                                 :changed_combination,
+                                 :target_name_id,
+                                 instance_ids_to_copy: [])
   end
 
   def dependent_params

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -52,6 +52,7 @@ import "typeahead_bundle";
 import "typeaheads_for_author_duplicate_of";
 
 import "typeaheads_for_instance_for_name_showing_reference_update";
+import "typeaheads_for_instance_target_name_for_copy_instances";
 import "typeaheads_for_instance_name";
 import "typeaheads_for_instance_name_for_unpub_citation";
 import "typeaheads_for_instance_reference";

--- a/app/javascript/controllers/checkbox_select_all_controller.js
+++ b/app/javascript/controllers/checkbox_select_all_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="checkbox-select-all"
+export default class extends Controller {
+  static targets = ["parent","child"]
+  connect() {
+    this.parentTarget.checked = false
+    this.childTargets.map( x => x.checked = false)
+  }
+
+  toggleChildren() {
+    if (this.parentTarget.checked) {
+      this.childTargets.map( x => x.checked = true)
+    } else {
+      this.childTargets.map( x => x.checked = false)
+    }
+  }
+
+  toggleParent() {
+    if (this.childTargets.map(x => x.checked).includes(false)) {
+      this.parentTarget.checked = false
+    } else {
+      this.parentTarget.checked = true
+    }
+    //console.log(this.childTargets.map(x => x.checked).includes(false))
+  }
+}

--- a/app/javascript/typeaheads/for_instance/target_name_for_copy_instances.js
+++ b/app/javascript/typeaheads/for_instance/target_name_for_copy_instances.js
@@ -1,0 +1,36 @@
+
+function setUpInstancesTargetName() {
+
+    $('#instance-target-name-typeahead').typeahead({highlight: true}, {
+        name: 'target-name-typeahead',
+        displayKey: 'value',
+        source: nameByFullName.ttAdapter()})
+        .on('typeahead:opened', function($e,datum) {
+            // Start afresh.
+        })
+        .on('typeahead:selected', function($e,datum) {
+            $('#name_target_name_id').val(datum.id);
+        })
+        .on('typeahead:autocompleted', function($e,datum) {
+            $('#name_target_name_id').val(datum.id);
+        })
+        .on('typeahead:closed', function($e,datum) {
+            // NOOP: cannot distinguish tabbing through vs emptying vs typing text.
+            // Users must select or autocomplete.
+        });
+}
+
+window.setUpInstancesTargetName = setUpInstancesTargetName;
+
+
+window.nameByFullName = new Bloodhound({
+    datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
+    queryTokenizer: Bloodhound.tokenizers.whitespace,
+    remote: window.relative_url_root + '/names/typeahead_on_full_name?term=%QUERY',
+    limit: 100
+});
+
+// kicks off the loading/processing of `local` and `prefetch`
+nameByFullName.initialize();
+
+window.nameByFullName = nameByFullName;

--- a/app/models/concerns/instance/copyable_to_new_name.rb
+++ b/app/models/concerns/instance/copyable_to_new_name.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Instance::CopyableToNewName
+  extend ActiveSupport::Concern
+
+  def copy_to_new_name(new_name_id, as_username)
+    raise "Copied record would have same name id." if new_name_id.eql?(name_id)
+
+    new = dup
+    new.name_id = new_name_id
+    new.created_by = new.updated_by = as_username
+    new.source_system = new.source_id = new.source_id_string = nil
+    new.uri = nil
+    new.lock_version = 0
+    new.save!
+    new
+  end
+
+  def citation_for_standalone
+    "#{reference.citation_html}".html_safe +
+    (page.present? ? ": #{page}" : "") +
+    (instance_type.try('primary_instance') ? "[#{instance_type.name}]" : "")
+  end
+
+  def instance_id_to_copy
+    id
+  end
+end

--- a/app/models/concerns/name/instances_copyable.rb
+++ b/app/models/concerns/name/instances_copyable.rb
@@ -1,0 +1,34 @@
+
+#
+# Names can copy their instances
+module Name::InstancesCopyable
+  extend ActiveSupport::Concern
+
+  def standalone_instances
+    instances.select {|i| i.instance_type.standalone?}
+  end
+
+  def standalone_instances_sorted
+    standalone_instances.sort {|x,y| x.reference.iso_publication_date <=> y.reference.iso_publication_date}
+  end
+
+  def standalone_instance_ids
+    standalone_instances.map {|si| si.id}
+  end
+
+  def verified_requested_instances(requested_instance_ids)
+    standalone_instances.select {|x| requested_instance_ids.include?(x.id.to_s)}
+  end
+
+  def copy_standalone_instances(target_name, requested_instance_ids, as_username)
+    copy_tally = 0
+    Name.transaction do
+      verified_requested_instances(requested_instance_ids).each do |instance|
+        instance.copy_to_new_name(target_name.id, as_username)  
+        copy_tally += 1
+      end
+    end
+    copy_tally
+  end
+end
+

--- a/app/models/instance.rb
+++ b/app/models/instance.rb
@@ -78,6 +78,7 @@ class Instance < ApplicationRecord
   include InstanceTreeable
   include InstanceInTaxonomy
   include Instance::ForCopyToLoaderName
+  include Instance::CopyableToNewName
 
   self.table_name = "instance"
   self.primary_key = "id"

--- a/app/models/name.rb
+++ b/app/models/name.rb
@@ -102,10 +102,13 @@ class Name < ApplicationRecord
   include NameRankable
   include NameEnterable
   include Name::Loadable
+  include Name::InstancesCopyable
 
   attr_accessor :display_as,
                 :give_me_focus,
-                :change_category_name_to
+                :change_category_name_to,
+                :target_name_id,
+                :instance_ids_to_copy
 
   belongs_to :name_type, optional: false
   has_one :name_category, through: :name_type

--- a/app/views/names/copy_instances/error.js.erb
+++ b/app/views/names/copy_instances/error.js.erb
@@ -1,0 +1,4 @@
+
+$('.message-container').html('').addClass('hidden');
+$('#copy-name-instances-error-message-container').removeClass('hidden').html('<%= "#{editor_icon('warning red')} #{escape_javascript(@message)}".html_safe %>');
+

--- a/app/views/names/copy_instances/success.js.erb
+++ b/app/views/names/copy_instances/success.js.erb
@@ -1,0 +1,11 @@
+$('.message-container').html('').addClass('hidden');
+$('#confirm-or-cancel-copy-name-link-container').addClass('hidden');
+
+$('#copy-name-instances-info-message-container')
+  .html('<%= link_to("#{pluralize(@tally, 'Instance')} copied - view target: #{editor_icon('search')}".html_safe,
+                     search_url(query_target: 'Names',
+                                query_string: "id:#{@target_name.id} si:"),
+                                title: "Query the target name") %>');
+
+$('#copy-name-instances-info-message-container').removeClass('hidden');
+$('#copy-name-link').removeClass('disabled');

--- a/app/views/names/form/_copy_instances.html.erb
+++ b/app/views/names/form/_copy_instances.html.erb
@@ -1,0 +1,91 @@
+
+<%= form_for(@name,
+             url: name_copy_instances_path(id: @name.id),
+             html: {id: "copy-name-form",
+                    role: 'form',
+                    remote: true,
+                    method: :post}) do |f| %>
+ <% if @name.errors.any? %>
+    <div id="error_explanation">
+      <h6><%= pluralize(@name.errors.count, "error") %> prevented this action:</h6>
+
+      <ul>
+      <% @name.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <input type="hidden" name="random_id" value="<%= params[:random_id] %>"/>
+  <%= f.hidden_field :target_name_id %>
+
+  <div class="form-group">
+    <label for="name">Target Name<span class='red'>*</span></label>
+    <div class="typeahead-container">
+      <section class='block width-100-percent'>
+        <input id="instance-target-name-typeahead"
+               class="typeahead form-control width-100-percent give-me-focus" 
+               tabindex="<%= increment_tab_index %>"
+               type="text" 
+               title="Select a name from the list of suggestions that appears as you type."
+               required="true"
+               placeholder="Name"
+               value=""/>
+      </section>
+    </div>
+    <script> setUpInstancesTargetName(); </script>
+  </div>
+
+
+  <div data-controller="checkbox-select-all">
+    <%= check_box_tag "all", nil, nil, {data: { checkbox_select_all_target: "parent", action: "change->checkbox-select-all#toggleChildren"}} %>
+    <%= label_tag "all" %>
+    <%# def collection_checkboxes(method, collection, value_method, text_method, options = {}, html_options = {}, &block) %>
+    <%= f.collection_checkboxes(:instance_ids_to_copy, 
+                                 @name.standalone_instances_sorted,
+                                 :instance_id_to_copy,
+                                 :citation_for_standalone,
+                                 options = {}, html_options = {}) do |b| %>
+    <div class="checkbox-line nowrap">
+      <%= b.check_box(data: {checkbox_select_all_target: "child", action: "change->checkbox-select-all#toggleParent"}) %>&nbsp;<%= b.label %>
+    </div>
+  <% end %>
+  </div>
+
+
+<br>
+<div class="width-100-percent"> 
+
+  <%= link_to("Copy...",
+             '#',
+             id: "copy-name-instances-link",
+             class: "btn btn-warning unconfirmed-action-link pull-right",
+             title: "Copy the name - you will be asked to confirm.",
+             tabindex: increment_tab_index,
+             data: {show_this_id: "confirm-or-cancel-copy-name-instances-link-container"})
+  %>
+  <div id="confirm-or-cancel-copy-name-instances-link-container"
+       class="confirm-or-cancel-container pull-right hidden">
+
+    <%= f.submit "Confirm", id: 'create-copy-of-name', class: 'btn btn-primary width-7em', title: 'Really copy the name', disabled: false, tabindex: increment_tab_index %>
+    <%= link_to("Cancel",
+                '#',
+                id: "cancel-copy-name-instances-link",
+                class: "btn btn-default cancel-link",
+                title: "Do not copy the name.",
+                tabindex: increment_tab_index,
+                data: {enable_this_id: 'copy-name-instances-link',
+                hide_this_id: "confirm-or-cancel-copy-name-instances-link-container"})
+    %>
+  </div>
+  <br>
+  <div id="copy-name-instances-info-message-container" class="message-container xwidth-100-percent xhidden"></div>
+  <div id="copy-name-instances-error-message-container" class="message-container error-container width-100-percent hidden"></div>
+</div>
+
+<br>
+<br>
+<br>
+<br>
+<% end %>

--- a/app/views/names/tabs/_tab_copy.html.erb
+++ b/app/views/names/tabs/_tab_copy.html.erb
@@ -2,9 +2,19 @@
 
 <br>
 <div>
-<h5>Copy</h5>
+<h5>Copy Name</h5>
 <%= render partial: 'names/form/copy' %>
 </div>
 <br>
 <div id="search-result-details-info-message-container" class="message-container"></div>
 <div id="search-result-details-error-message-container" class="message-container"></div>
+
+
+
+<%= divider %>
+<div>
+  <h5>Copy Standalone Instances</h5>
+  <p>Copy up to <%= pluralize(@name.standalone_instances.size, 'standalone instance') %> to another Name record</p>
+  <%= render partial: 'names/form/copy_instances' %>
+</div>
+

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 19-May-2026
+  :jira_id: '1319'
+  :description: |-
+    Names and Instances: Allow copy of Instances from one Name to another Name
+- :date: 19-May-2026
   :jira_id: '237'
   :jira_project: FLOR
   :description: |-

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -58,6 +58,7 @@ pin "typeaheads_for_author_duplicate_of", to: "typeaheads/for_author/duplicate_o
 pin "typeaheads_for_instance_for_name_showing_reference_update",
     to: "typeaheads/for_instance/for_name_showing_reference_update.js"
 pin "typeaheads_for_instance_name", to: "typeaheads/for_instance/name.js"
+pin "typeaheads_for_instance_target_name_for_copy_instances", to: "typeaheads/for_instance/target_name_for_copy_instances.js"
 pin "typeaheads_for_instance_name_for_unpub_citation", to: "typeaheads/for_instance/name_for_unpub_citation.js"
 pin "typeaheads_for_instance_reference", to: "typeaheads/for_instance/reference.js"
 pin "typeaheads_for_instance_reference_profile_v2", to: "typeaheads/for_instance/reference_profile_v2.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -194,6 +194,9 @@ Rails.application.routes.draw do
   match "names/:id/tab/:tab/as/:new_category",
         as: "name_edit_as_category", to: "names#edit_as_category", via: :get
   match "names/:id/copy", as: "name_copy", to: "names#copy", via: :post
+
+  match "/names/:id/copy/instances", as: "name_copy_instances", to: "names#copy_instances", via: :post
+
   match "names/new/:category/:random_id",
         as: "new_name_with_category_and_random_id", to: "names#new", via: :get
 

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.3
+appversion=5.1.3.4

--- a/test/controllers/search/focus/simple_test.rb
+++ b/test/controllers/search/focus/simple_test.rb
@@ -34,7 +34,7 @@ class SearchNamesWithFocusSimpleTest < ActionController::TestCase
                    groups: [] })
     assert_response :success
     assert_select "#search-results-summary",
-                  /4[0-9] names of 4[0-9]/,
+                  /[45][0-9] names of [45][0-9]/,
                   "Should find plenty of records for a simple search on 'a'"
     assert_select "#focus_id[value='#{@name.id}']", { count: 1 }, "One Focus"
   end

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -2635,5 +2635,19 @@ darwinia_sp_7:
   name_path: 'Eukaryota/Plantae/Magnoliophyta/Magnoliopsida/Rosidae/Myrtales/Myrtaceae/Darwinia/sp.'
   uri: agh
 
+angophora_fred: 
+  <<: *DEFAULTS
+  simple_name: Angophora fred
+  full_name: Angophora fred (Gaertn.) Britten
+  name_element: fred
+  name_rank: species
+  name_status: unknown
+  name_type: scientific
+  namespace: apni
+  parent: angophora
+  family: a_family
+  author: moe
+  name_path: 'Plantae/Magnoliophyta/a_family/a_genus/fred'
+  uri: agi
 
 

--- a/test/integration/name/copy_instances/need_edit_role_test.rb
+++ b/test/integration/name/copy_instances/need_edit_role_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single controller test.
+class NamesCopyInstancesNeedEditRole < ActionController::TestCase
+  tests NamesController
+
+  test "user needs edit role to copy name standalone instances" do
+    source_name = names(:angophora_costata)
+    target_name = names(:angophora_fred)
+    assert_difference('Instance.count', 0) do
+      post(:copy_instances,
+             params: { name: { "target_name_id" => target_name.id.to_s,
+                               "instance_ids_to_copy" => source_name.standalone_instances.map(&:id) },
+                       "commit" => "Confirm",
+                       format: :js,
+                       "id" => source_name.id.to_s
+                     },
+             session: { username: "fred",
+                        user_full_name: "Fred Jones",
+                        groups: ["login"] }
+            )
+    end
+  end
+end
+

--- a/test/integration/name/copy_instances/route_test.rb
+++ b/test/integration/name/copy_instances/route_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+class NamesCopyInstancesRoute < ActionController::TestCase
+  tests NamesController
+
+  test "name copy instances route" do
+    assert_routing({ path: "/names/44/copy/instances", method: :post },
+                   { controller: "names", action: "copy_instances", id: "44" }
+                  )
+  end
+end
+

--- a/test/integration/name/copy_instances/simple_test.rb
+++ b/test/integration/name/copy_instances/simple_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single controller test.
+class NamesCopyInstancesSimple < ActionController::TestCase
+  tests NamesController
+
+  test "editor should be able to copy name standalone instances to another name" do
+    source_name = names(:angophora_costata)
+    target_name = names(:angophora_fred)
+    assert_difference('Instance.count', source_name.standalone_instances.size) do
+      post(:copy_instances,
+             params: { name: { "target_name_id" => target_name.id.to_s,
+                               "instance_ids_to_copy" => source_name.standalone_instances.map(&:id) },
+                       "commit" => "Confirm",
+                       format: :js,
+                       "id" => source_name.id.to_s
+                     },
+             session: { username: "fred",
+                        user_full_name: "Fred Jones",
+                        groups: ["edit"] }
+            )
+    end
+  end
+end
+

--- a/test/integration/name/copy_instances/standalones_only_test.rb
+++ b/test/integration/name/copy_instances/standalones_only_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Single controller test.
+class NamesCopyInstancesStandalonesOnlyTest < ActionController::TestCase
+  tests NamesController
+
+  test "standalone instances only should be copied" do
+    source_name = names(:angophora_costata)
+    target_name = names(:angophora_fred)
+    assert source_name.instances.size > source_name.standalone_instances.size, "Need some non-standalone instances for this test"
+    assert_difference('Instance.count', source_name.standalone_instances.size) do
+    post(:copy_instances,
+         params: { name: { "target_name_id" => target_name.id.to_s,
+                           "instance_ids_to_copy" => source_name.instances.map(&:id) },
+                   "commit" => "Confirm",
+                   format: :js,
+                   "id" => source_name.id.to_s
+                 },
+         session: { username: "fred",
+                    user_full_name: "Fred Jones",
+                    groups: ["edit"] }
+        )
+    end
+  end
+end
+


### PR DESCRIPTION
## Description
Detail in Jira, but basically this PR offers a GUI for Users with the edit role to selectively copy standalone instances from one Name to another Name.  GUI is on the Name -> Copy tab.

## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How to Test
See Jira and Description above.

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
