### PR TITLE
Add loading state and disable buttons on confirm delete

### DIFF
--- a/app/assets/stylesheets/components/new-for-rails-6.css
+++ b/app/assets/stylesheets/components/new-for-rails-6.css
@@ -87,3 +87,15 @@ ul#tree-report-tabs.nav-tabs li a:focus {
   color: purple;
 }
 
+a.btn-danger[disabled],
+a.btn-default[disabled] {
+  opacity: 0.55;
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+a.btn-danger[disabled] {
+  background-color: #a94442;
+  border-color: #843534;
+}
+

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -19,6 +19,7 @@ import "instance_note_edit";
 import "add_new_row";
 import "menu_ops";
 import "unconfirmed_action_link_click";
+import "confirm_delete_link_click";
 import "loader_bulk_show_stats_ops";
 import "name_rank_id_changed";
 import "name_delete_form_submit";

--- a/app/javascript/confirm_delete_link_click.js
+++ b/app/javascript/confirm_delete_link_click.js
@@ -3,7 +3,8 @@
     $('body').on('click', 'a.confirm-delete-btn', function() {
       var $btn = $(this);
       $btn.attr('disabled', 'disabled')
-          .html('<i class="fa fa-spinner fa-spin"></i> ' + $btn.text().trim());
+          .prepend(document.createTextNode(' '))
+          .prepend($('<i>').addClass('fa fa-spinner fa-spin'));
       $btn.siblings('.cancel-link').attr('disabled', 'disabled');
     });
   });

--- a/app/javascript/confirm_delete_link_click.js
+++ b/app/javascript/confirm_delete_link_click.js
@@ -1,0 +1,10 @@
+(function() {
+  $(document).on("turbo:load", function() {
+    $('body').on('click', 'a.confirm-delete-btn', function() {
+      var $btn = $(this);
+      $btn.attr('disabled', 'disabled')
+          .html('<i class="fa fa-spinner fa-spin"></i> ' + $btn.text().trim());
+      $btn.siblings('.cancel-link').attr('disabled', 'disabled');
+    });
+  });
+}).call(this);

--- a/app/views/authors/_delete_widgets.html.erb
+++ b/app/views/authors/_delete_widgets.html.erb
@@ -10,7 +10,7 @@
 %>
 <% confirm_delete_link = link_to("Confirm delete",
                                  author_path(@author.id),
-                                 class: "btn btn-danger",
+                                 class: "btn btn-danger confirm-delete-btn",
                                  tabindex: increment_tab_index,
                                  title: "Confirm you want to delete the author.",
                                  remote: true,

--- a/app/views/comments/_delete_widgets.html.erb
+++ b/app/views/comments/_delete_widgets.html.erb
@@ -10,7 +10,7 @@
 
 <% confirm_delete_link = link_to("Confirm delete",
                                  comment_path(comment.id),
-                                 class: "btn btn-danger",
+                                 class: "btn btn-danger confirm-delete-btn",
                                  tabindex: increment_tab_index,
                                  title: "Confirm you want to delete the comment.",
                                  remote: true,

--- a/app/views/instances/_delete_widgets.html.erb
+++ b/app/views/instances/_delete_widgets.html.erb
@@ -26,7 +26,7 @@
   <% confirm_delete_link = link_to("Confirm delete",
                                    instance_path(@instance.id),
                                    id: "confirm-delete-link",
-                                   class: "btn btn-danger",
+                                   class: "btn btn-danger confirm-delete-btn",
                                    tabindex: increment_tab_index,
                                    title: "Confirm the delete.",
                                    remote: true,

--- a/app/views/loader/batch/review/periods/widgets/_delete_widgets.html.erb
+++ b/app/views/loader/batch/review/periods/widgets/_delete_widgets.html.erb
@@ -19,7 +19,7 @@
 %>
 <% confirm_delete_link = link_to("Confirm delete",
                                  delete_review_period_path(@review_period),
-                                 class: "btn btn-danger",
+                                 class: "btn btn-danger confirm-delete-btn",
                                  tabindex: increment_tab_index,
                                  title: "Confirm you want to delete batch review period.",
                                  remote: true,

--- a/app/views/loader/batch/reviewers/forms/_delete_widgets.html.erb
+++ b/app/views/loader/batch/reviewers/forms/_delete_widgets.html.erb
@@ -17,7 +17,7 @@
   <% confirm_delete_link = link_to("Remove",
                                    delete_batch_reviewer_path(reviewer.id),
                                    id: "confirm-delete-reviewer-#{reviewer.id}-link",
-                                   class: "btn btn-danger hidden",
+                                   class: "btn btn-danger confirm-delete-btn hidden",
                                    tabindex: increment_tab_index,
                                    title: "Confirm the delete.",
                                    remote: true,

--- a/app/views/loader/batch/reviews/widgets/_delete_widgets.html.erb
+++ b/app/views/loader/batch/reviews/widgets/_delete_widgets.html.erb
@@ -19,7 +19,7 @@
 %>
 <% confirm_delete_link = link_to("Confirm delete",
                                  delete_batch_review_path(@batch_review),
-                                 class: "btn btn-danger",
+                                 class: "btn btn-danger confirm-delete-btn",
                                  tabindex: increment_tab_index,
                                  title: "Confirm you want to delete batch review.",
                                  remote: true,

--- a/app/views/loader/names/review/tabs/main/votes/votable/voting_in_progress/can_vote/not_heading/vote/_delete_widgets.html.erb
+++ b/app/views/loader/names/review/tabs/main/votes/votable/voting_in_progress/can_vote/not_heading/vote/_delete_widgets.html.erb
@@ -11,7 +11,7 @@
 
   <%= link_to("Confirm delete",
               delete_name_review_vote_path(vote.loader_name_id, vote.batch_review_id, vote.org_id),
-              class: "btn btn-danger",
+              class: "btn btn-danger confirm-delete-btn",
               title: "Confirm you want to delete the vote.",
               remote: true,
               method: :delete)

--- a/app/views/loader/names/tabs/_delete_widgets.html.erb
+++ b/app/views/loader/names/tabs/_delete_widgets.html.erb
@@ -19,7 +19,7 @@
 %>
 <% confirm_delete_link = link_to("Confirm delete",
                                  loader_name_path(@loader_name.id),
-                                 class: "btn btn-danger delete-widget",
+                                 class: "btn btn-danger confirm-delete-btn delete-widget",
                                  tabindex: increment_tab_index,
                                  title: "Confirm you want to delete the loader name.",
                                  remote: true,

--- a/app/views/loader/names/tabs/in_batch_note_record_tabs/_delete_widgets.html.erb
+++ b/app/views/loader/names/tabs/in_batch_note_record_tabs/_delete_widgets.html.erb
@@ -18,7 +18,7 @@
 %>
 <% confirm_delete_link = link_to("Confirm delete",
                                  loader_name_path(@loader_name.id),
-                                 class: "btn btn-danger delete-widget",
+                                 class: "btn btn-danger confirm-delete-btn delete-widget",
                                  tabindex: increment_tab_index,
                                  title: "Confirm you want to delete the loader name.",
                                  remote: true,

--- a/app/views/name_tag_names/_delete_widgets.html.erb
+++ b/app/views/name_tag_names/_delete_widgets.html.erb
@@ -11,7 +11,7 @@
 
 <% confirm_delete_link = link_to("Confirm delete",
                                  delete_name_tag_name_path(name_id:name_tag_name.name_id,tag_id: name_tag_name.tag_id),
-                                 class: "btn btn-danger",
+                                 class: "btn btn-danger confirm-delete-btn",
                                  title: "Really removes the tag.",
                                  tabindex: increment_tab_index,
                                  remote: true,

--- a/app/views/profile_item_references/_delete_widgets.html.erb
+++ b/app/views/profile_item_references/_delete_widgets.html.erb
@@ -13,7 +13,7 @@
 # if we want it to render the results via turbo stream. Just something we have to note of.
 confirm_delete_link = link_to("Confirm delete",
                                 delete_profile_item_references_path(profile_item_id: profile_item_reference.profile_item_id, reference_id: profile_item_reference.reference_id),
-                                class: "btn btn-danger",
+                                class: "btn btn-danger confirm-delete-btn",
                                 style: "margin-top: 3px;margin-bottom: 3px;",
                                 title: "Select to confirm the delete.",
                                 data: {

--- a/app/views/profile_items/_delete_widgets.html.erb
+++ b/app/views/profile_items/_delete_widgets.html.erb
@@ -13,7 +13,7 @@
 # if we want it to render the results via turbo stream. Just something we have to note of.
 confirm_delete_link = link_to("Confirm delete",
                                 profile_item_path(profile_item.id),
-                                class: "btn btn-danger",
+                                class: "btn btn-danger confirm-delete-btn",
                                 style: "margin-top: 3px;margin-bottom: 3px;",
                                 title: "Select to confirm the delete.",
                                 data: {

--- a/app/views/users/tabs/_delete_widgets.html.erb
+++ b/app/views/users/tabs/_delete_widgets.html.erb
@@ -11,7 +11,7 @@
 %>
 <% confirm_delete_link = link_to("Confirm delete",
                                  user_path(@user.id),
-                                 class: "btn btn-danger",
+                                 class: "btn btn-danger confirm-delete-btn",
                                  tabindex: increment_tab_index,
                                  title: "Confirm you want to delete the user.",
                                  remote: true,

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,8 @@
+- :date: 20-May-2026
+  :jira_id: '222'
+  :jira_project: FLOR
+  :description: |-
+    Add loading state and disable the button on confirm delete widgets
 - :date: 19-May-2026
   :jira_id: '1319'
   :description: |-

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -16,6 +16,7 @@ pin "instance_note_edit", preload: true
 pin "add_new_row", preload: true
 pin "menu_ops", preload: true
 pin "unconfirmed_action_link_click", preload: true
+pin "confirm_delete_link_click", preload: true
 pin "name_rank_id_changed", preload: true
 pin "loader_bulk_show_stats_ops", preload: true
 pin "name_delete_form_submit", preload: true

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.4
+appversion=5.1.3.5


### PR DESCRIPTION
## Summary
- Confirm delete buttons across all delete widgets now show a spinner and become visually disabled when clicked, preventing double-submissions and giving clear feedback that the action is in progress
- Cancel delete button is simultaneously disabled when confirm is clicked, preventing the user from cancelling mid-flight
- Centralised the behaviour into a single `confirm_delete_link_click.js` handler

## Type of change
UI improvement / bug fix — addresses a gap where confirm delete buttons remained visually active and clickable after being clicked, with no feedback that a request was in progress.

## Technical details
The fix uses an explicit delegated click handler that calls `$(this).attr('disabled', 'disabled')` (sets the DOM attribute) and injects the spinner via `.html()` using the button's own text, so it works for both "Confirm delete" and "Remove" labels without hardcoding.

## Test plan 
  - [x] Click "Delete Instance" → click "Confirm delete" → spinner appears on confirm button, both confirm and cancel become visually dimmed and unclickable
  - [x] Verify the same behaviour on: author delete, comment delete, name tag delete, user delete
  - [x] Verify on loader name delete, in-batch-note delete, batch review delete, batch review period delete, batch reviewer remove, vote delete
  - [x] Verify on profile item delete and profile item reference delete (these use Turbo Stream rather than `remote: true`)
  - [x] Confirm the dimmed button style shows reduced opacity and `not-allowed` cursor on hover while disabled
  - [x] Confirm the name delete form (names widget) is unaffected — it has its own handler via `name_delete_form_submit.js`

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
