### PR TITLE
Fix Jira ID references for change name workflow in changes-2026.yml

### DIFF
--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -23,15 +23,15 @@
   :description: |-
     Fixup the display of the Tree tab for user with/without tree permission
 - :date: 05-May-2026
-  :jira_id: '5896'
+  :jira_id: '5796'
   :description: |-
     UI integration for the change name workflow for draft instances
 - :date: 04-May-2026
-  :jira_id: '5896'
+  :jira_id: '5796'
   :description: |-
     Change name controller and js template changes to support the change name workflow for draft instances
 - :date: 04-May-2026
-  :jira_id: '5896'
+  :jira_id: '5796'
   :description: |-
     Ability and service object changes to support the change name workflow for draft instances
 - :date: 01-May-2026

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 20-May-2026
+  :jira_id: ''
+  :description: |-
+    Fixup the typo in the changelog for jira 5896 -> 5796
+- :date: 20-May-2026
   :jira_id: '222'
   :jira_project: FLOR
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.5
+appversion=5.1.3.6


### PR DESCRIPTION
## Description
Fixup a typo in the change log around jira id

## Type of change
- [x] Chore

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
