### PR TITLE
Flor-221 - Restrict "More" and "Tag" tabs to users with name edit permissions

### DIFF
--- a/app/helpers/tabs_helper.rb
+++ b/app/helpers/tabs_helper.rb
@@ -44,4 +44,14 @@ module TabsHelper
 
     tabs_array.include?(tab_name)
   end
+
+  def can_edit_name?(name)
+    if can?(:manage, Name)
+      true
+    elsif can?(:update_common_name, name)
+      name.name_type&.name&.downcase == "common"
+    else
+      false
+    end
+  end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -316,6 +316,9 @@ class Ability
     can "names", "tab_details"
     can "names", "tab_edit"
     can "names", "update"
+    can "names", "tab_tag"
+    can "names", "tab_more"
+    can "name_tag_names", :all
   end
 
   def basic_auth_1

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -318,6 +318,7 @@ class Ability
     can "names", "update"
     can "names", "tab_tag"
     can "names", "tab_more"
+    can "names", "tab_refresh"
     can "name_tag_names", :all
   end
 

--- a/app/views/names/tabs/_tab_comments.html.erb
+++ b/app/views/names/tabs/_tab_comments.html.erb
@@ -1,18 +1,18 @@
-<%= render partial: 'names/tabs/tabs_row_2' unless @tab.match(/tab_more/) %>
+<% if can_edit_name?(@name) %>
+    <%= render partial: 'names/tabs/tabs_row_2' unless @tab.match(/tab_more/) %>
 
-<div id="search-result-details-info-message-container" class="message-container"></div>
-<div id="search-result-details-error-message-container" class="message-container"></div>
-<% increment_tab_index(0) %>
+    <div id="search-result-details-info-message-container" class="message-container"></div>
+    <div id="search-result-details-error-message-container" class="message-container"></div>
+    <% increment_tab_index(0) %>
 
-<div id="name-comments-fields" >
+    <div id="name-comments-fields" >
 
-    <% @name.comments.sort{|x,y| x.created_at <=> y.created_at}.each do |comment| %>
-        <div id="container-for-comment-<%= comment.id %>">
-            <%= render partial: 'comments/form', locals: {comment: comment} %>
-        </div>
-    <% end %>
+        <% @name.comments.sort{|x,y| x.created_at <=> y.created_at}.each do |comment| %>
+            <div id="container-for-comment-<%= comment.id %>">
+                <%= render partial: 'comments/form', locals: {comment: comment} %>
+            </div>
+        <% end %>
 
-    <%= render partial: 'comments/form_new', locals: {comment: Comment.new, parent_entity_type: 'name', parent_id: @name.id} %>
-</div>
-
-
+        <%= render partial: 'comments/form_new', locals: {comment: Comment.new, parent_entity_type: 'name', parent_id: @name.id} %>
+    </div>
+<% end %>

--- a/app/views/names/tabs/_tab_more.html.erb
+++ b/app/views/names/tabs/_tab_more.html.erb
@@ -3,9 +3,11 @@
   tabs_array = tabs.collect{|tab| tab[:tab] }
 %>
 
-<% increment_tab_index(0) %>
-<%= render partial: "names/tabs/tabs_row_2" %>
+<% if can_edit_name?(@name) %>
+  <% increment_tab_index(0) %>
+  <%= render partial: "names/tabs/tabs_row_2" %>
 
-<% if tab_available?(tabs_array, "more_comment") %>
-  <%= render partial: "names/tabs/tab_comments" %>
+  <% if tab_available?(tabs_array, "more_comment") %>
+    <%= render partial: "names/tabs/tab_comments" %>
+  <% end %>
 <% end %>

--- a/app/views/names/tabs/_tab_refresh.html.erb
+++ b/app/views/names/tabs/_tab_refresh.html.erb
@@ -1,10 +1,12 @@
-<%= render partial: 'names/tabs/tabs_row_2' %>
-<% increment_tab_index %>
+<% if can_edit_name?(@name) %>
+  <%= render partial: 'names/tabs/tabs_row_2' %>
+  <% increment_tab_index %>
 
-<div>
-<%= render partial: 'names/tabs/refresh_widgets' %>
-</div>
+  <div>
+  <%= render partial: 'names/tabs/refresh_widgets' %>
+  </div>
 
 
-<div id="search-result-details-info-message-container" class="message-container"></div>
-<div id="search-result-details-error-message-container" class="message-container"></div>
+  <div id="search-result-details-info-message-container" class="message-container"></div>
+  <div id="search-result-details-error-message-container" class="message-container"></div>
+<% end %>

--- a/app/views/names/tabs/_tab_tag.html.erb
+++ b/app/views/names/tabs/_tab_tag.html.erb
@@ -1,16 +1,16 @@
-<%= render partial: 'names/tabs/tabs_row_2' %>
+<% if can_edit_name?(@name) %>
+  <%= render partial: 'names/tabs/tabs_row_2' %>
 
-<% increment_tab_index %>
-<br>
+  <% increment_tab_index %>
+  <br>
 
-<% if NameTag.all.count > 0 %>
-  <div>
-  <h5>Tags</h5>
-  <%= render partial: 'names/tabs/name_tag_widgets' %>
-  </div>
+  <% if NameTag.all.count > 0 %>
+    <div>
+    <h5>Tags</h5>
+    <%= render partial: 'names/tabs/name_tag_widgets' %>
+    </div>
+  <% end %>
+
+  <div id="search-result-details-info-message-container" class="message-container"></div>
+  <div id="search-result-details-error-message-container" class="message-container"></div>
 <% end %>
-
-<div id="search-result-details-info-message-container" class="message-container"></div>
-<div id="search-result-details-error-message-container" class="message-container"></div>
-
-

--- a/app/views/names/tabs/_tabs.html.erb
+++ b/app/views/names/tabs/_tabs.html.erb
@@ -19,14 +19,7 @@
     })
   %>
 
-  <%
-    can_edit_this_name = if can?(:manage, Name)
-                            true
-                          elsif can?(:update_common_name, @name) && !can?(:manage, Name)
-                            @name.name_type&.name&.downcase == "common"
-                          end
-  %>
-  <% if can?("names", "update") && can_edit_this_name %>
+  <% if can?("names", "update") && can_edit_name?(@name) %>
     <%= render(
       partial: "names/tabs/tab",
       locals: {
@@ -126,7 +119,7 @@
     %>
   <% end %>
 
-  <% if can?("names", "update") && tab_available?(tabs_array, "more") %>
+  <% if can_edit_name?(@name) && tab_available?(tabs_array, "more") %>
     <%= render(
       partial: "names/tabs/tab",
       locals: {

--- a/app/views/names/tabs/_tabs_row_2.html.erb
+++ b/app/views/names/tabs/_tabs_row_2.html.erb
@@ -4,7 +4,7 @@
 %>
 
 <ul class="nav nav-tabs">
-  <% if can?("names", "update") %>
+  <% if can_edit_name?(@name) %>
     <% if tab_available?(tabs_array, "more_comment") %>
       <%= render partial: "names/tabs/tab",
         locals: {

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -2,7 +2,7 @@
   :jira_id: '221'
   :jira_project: FLOR
   :description: |-
-    Restrict "More" and "Tag" tabs to users with name edit permissions
+    Restrict "More" and sub tabs to users with name edit permissions
 - :date: 21-May-2026
   :jira_id: '2958'
   :description: |-

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,8 @@
+- :date: 22-May-2026
+  :jira_id: '221'
+  :jira_project: FLOR
+  :description: |-
+    Restrict "More" and "Tag" tabs to users with name edit permissions
 - :date: 21-May-2026
   :jira_id: '2958'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.9
+appversion=5.1.3.10

--- a/spec/helpers/tabs_helper_spec.rb
+++ b/spec/helpers/tabs_helper_spec.rb
@@ -122,6 +122,65 @@ RSpec.describe TabsHelper, type: :helper do
     end
   end
 
+  describe '#can_edit_name?' do
+    let(:common_name_type) { instance_double(NameType, name: "common") }
+    let(:scientific_name_type) { instance_double(NameType, name: "scientific") }
+    let(:name_with_common_type) { instance_double(Name, name_type: common_name_type) }
+    let(:name_with_scientific_type) { instance_double(Name, name_type: scientific_name_type) }
+    let(:name_with_nil_type) { instance_double(Name, name_type: nil) }
+
+    context "when the user can manage Name" do
+      before { helper.define_singleton_method(:can?) { |*_| true } }
+
+      it "returns true regardless of name type" do
+        expect(helper.can_edit_name?(name_with_scientific_type)).to be true
+      end
+
+      it "returns true for common names" do
+        expect(helper.can_edit_name?(name_with_common_type)).to be true
+      end
+    end
+
+    context "when the user cannot manage Name" do
+      before do
+        manage_name = false
+        name_ref = name_with_common_type
+        helper.define_singleton_method(:can?) do |action, subject|
+          action == :update_common_name && subject == name_ref
+        end
+      end
+
+      it "returns true when name type is common" do
+        expect(helper.can_edit_name?(name_with_common_type)).to be true
+      end
+    end
+
+    context "when the user can update_common_name but name type is not common" do
+      before do
+        name_ref = name_with_scientific_type
+        helper.define_singleton_method(:can?) do |action, subject|
+          action == :update_common_name && subject == name_ref
+        end
+      end
+
+      it "returns false" do
+        expect(helper.can_edit_name?(name_with_scientific_type)).to be false
+      end
+    end
+
+    context "when the user has no relevant permissions" do
+      before { helper.define_singleton_method(:can?) { |*_| false } }
+
+      it "returns false for a common name" do
+        expect(helper.can_edit_name?(name_with_common_type)).to be false
+      end
+
+      it "returns false when name_type is nil" do
+        expect(helper.can_edit_name?(name_with_nil_type)).to be false
+      end
+    end
+  end
+
   describe '#tab_available?' do
     let(:tabs_array) { ['details', 'edit', 'comments'] }
 

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1385,6 +1385,18 @@ RSpec.describe Ability, type: :model do
       it "allows names update action" do
         expect(subject.can?("names", "update")).to eq true
       end
+
+      it "allows names tab_tag action" do
+        expect(subject.can?("names", "tab_tag")).to eq true
+      end
+
+      it "allows names tab_more action" do
+        expect(subject.can?("names", "tab_more")).to eq true
+      end
+
+      it "allows all actions on name_tag_names" do
+        expect(subject.can?("name_tag_names", :all)).to eq true
+      end
     end
   end
 

--- a/spec/views/names/tabs/tab_more_partial_spec.rb
+++ b/spec/views/names/tabs/tab_more_partial_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "names/tabs/_tab_more.html.erb", type: :view do
+  let(:name) { create(:name) }
+  let(:product_tab_service_mock) do
+    instance_double(Products::ProductTabService, all_available_tabs: { "name" => [] })
+  end
+
+  before do
+    allow(view).to receive(:can?).with(:manage, Name).and_return(false)
+    allow(view).to receive(:can?).with(:update_common_name, name).and_return(false)
+    allow(view).to receive(:increment_tab_index).and_return(1)
+    stub_template "names/tabs/_tabs_row_2.html.erb" => '<div id="tabs-row-2-stub"></div>'
+    stub_template "names/tabs/_tab_comments.html.erb" => '<div id="tab-comments-stub">comments</div>'
+
+    mock_service = product_tab_service_mock
+    view.define_singleton_method(:product_tab_service) { mock_service }
+
+    assign(:name, name)
+    allow(Rails.configuration).to receive(:multi_product_tabs_enabled).and_return(false)
+  end
+
+  subject { render partial: "names/tabs/tab_more" }
+
+  context "when the user cannot edit the name" do
+    it "renders no content" do
+      subject
+      expect(rendered.strip).to be_empty
+    end
+  end
+
+  context "when the user can edit the name" do
+    before { allow(view).to receive(:can?).with(:manage, Name).and_return(true) }
+
+    it "renders the tabs_row_2 partial" do
+      subject
+      expect(rendered).to have_selector("#tabs-row-2-stub")
+    end
+
+    context "and the more_comment tab is available" do
+      let(:product_tab_service_mock) do
+        instance_double(Products::ProductTabService, all_available_tabs: { "name" => [{ tab: "more_comment" }] })
+      end
+
+      it "renders the tab_comments partial" do
+        subject
+        expect(rendered).to have_selector("#tab-comments-stub")
+      end
+    end
+
+    context "and the more_comment tab is not configured" do
+      before do
+        allow(Rails.configuration).to receive(:multi_product_tabs_enabled).and_return(true)
+        mock_context_service = instance_double(Products::ProductContextService, available_contexts: [1])
+        view.define_singleton_method(:product_context_service) { mock_context_service }
+      end
+
+      it "does not render the tab_comments partial" do
+        subject
+        expect(rendered).not_to have_selector("#tab-comments-stub")
+      end
+    end
+  end
+end

--- a/spec/views/names/tabs/tab_tag_partial_spec.rb
+++ b/spec/views/names/tabs/tab_tag_partial_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "names/tabs/_tab_tag.html.erb", type: :view do
+  let(:name) { create(:name) }
+
+  before do
+    allow(view).to receive(:can?).with(:manage, Name).and_return(false)
+    allow(view).to receive(:can?).with(:update_common_name, name).and_return(false)
+    allow(view).to receive(:increment_tab_index).and_return(1)
+    stub_template "names/tabs/_tabs_row_2.html.erb" => ""
+    stub_template "names/tabs/_name_tag_widgets.html.erb" => "<p>tag widgets</p>"
+    assign(:name, name)
+  end
+
+  subject { render partial: "names/tabs/tab_tag" }
+
+  context "when the user cannot edit the name" do
+    it "renders no content" do
+      subject
+      expect(rendered.strip).to be_empty
+    end
+  end
+
+  context "when the user can edit the name" do
+    before { allow(view).to receive(:can?).with(:manage, Name).and_return(true) }
+
+    context "and there are name tags" do
+      before { allow(NameTag).to receive(:all).and_return(double(count: 2)) }
+
+      it "renders the Tags heading" do
+        subject
+        expect(rendered).to have_selector("h5", text: "Tags")
+      end
+
+      it "renders the message containers" do
+        subject
+        expect(rendered).to have_selector("#search-result-details-info-message-container")
+        expect(rendered).to have_selector("#search-result-details-error-message-container")
+      end
+    end
+
+    context "and there are no name tags" do
+      before { allow(NameTag).to receive(:all).and_return(double(count: 0)) }
+
+      it "does not render the Tags heading" do
+        subject
+        expect(rendered).not_to have_selector("h5", text: "Tags")
+      end
+
+      it "still renders the message containers" do
+        subject
+        expect(rendered).to have_selector("#search-result-details-info-message-container")
+        expect(rendered).to have_selector("#search-result-details-error-message-container")
+      end
+    end
+  end
+end

--- a/spec/views/names/tabs/tabs_partial_spec.rb
+++ b/spec/views/names/tabs/tabs_partial_spec.rb
@@ -129,4 +129,57 @@ RSpec.describe("names/tabs/_tabs.html.erb", type: :view) do
       expect(rendered).to(have_link("Delete name", id: "name-delete-tab"))
     end
   end
+
+  context "More tab visibility" do
+    context "when the user can manage Name" do
+      before do
+        allow(view).to(receive(:can?).with(:manage, Name).and_return(true))
+      end
+
+      it "renders the More tab" do
+        subject
+        expect(rendered).to(have_link("More", id: "name-more-tab"))
+      end
+    end
+
+    context "when the user can update_common_name on a common name" do
+      let(:common_name_type) { instance_double(NameType, name: "common") }
+      let(:name) { instance_double(Name, name_type: common_name_type, duplicate?: false) }
+
+      before do
+        allow(view).to(receive(:can?).with(:manage, Name).and_return(false))
+        allow(view).to(receive(:can?).with(:update_common_name, name).and_return(true))
+        assign(:name, name)
+      end
+
+      it "renders the More tab" do
+        subject
+        expect(rendered).to(have_link("More", id: "name-more-tab"))
+      end
+    end
+
+    context "when the user can update_common_name but the name is not common" do
+      before do
+        allow(view).to(receive(:can?).with(:manage, Name).and_return(false))
+        allow(view).to(receive(:can?).with(:update_common_name, name).and_return(true))
+      end
+
+      it "does not render the More tab" do
+        subject
+        expect(rendered).not_to(have_link("More", id: "name-more-tab"))
+      end
+    end
+
+    context "when the user has no edit permissions" do
+      before do
+        allow(view).to(receive(:can?).with(:manage, Name).and_return(false))
+        allow(view).to(receive(:can?).with(:update_common_name, name).and_return(false))
+      end
+
+      it "does not render the More tab" do
+        subject
+        expect(rendered).not_to(have_link("More", id: "name-more-tab"))
+      end
+    end
+  end
 end

--- a/spec/views/names/tabs/tabs_row_2_partial_spec.rb
+++ b/spec/views/names/tabs/tabs_row_2_partial_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe "names/tabs/_tabs_row_2.html.erb", type: :view do
+  let(:name) { create(:name) }
+  let(:product_tab_service_mock) do
+    instance_double(Products::ProductTabService, all_available_tabs: { "name" => [] })
+  end
+
+  before do
+    allow(view).to receive(:can?).with(:manage, Name).and_return(false)
+    allow(view).to receive(:can?).with(:update_common_name, name).and_return(false)
+    allow(view).to receive(:can?).with("names", "update").and_return(false)
+    allow(view).to receive(:increment_tab_index).and_return(1)
+    allow(NameTag).to receive(:all).and_return(double(count: 0))
+
+    mock_service = product_tab_service_mock
+    view.define_singleton_method(:product_tab_service) { mock_service }
+
+    assign(:name, name)
+    assign(:tab, "tab_show_1")
+    allow(Rails.configuration).to receive(:multi_product_tabs_enabled).and_return(false)
+  end
+
+  subject { render partial: "names/tabs/tabs_row_2" }
+
+  context "when the user cannot edit the name" do
+    it "does not render the Comment tab" do
+      subject
+      expect(rendered).not_to have_link("Comment", id: "name-comment-tab")
+    end
+
+    it "does not render the Tag tab" do
+      subject
+      expect(rendered).not_to have_link("Tag", id: "name-tags-tab")
+    end
+
+    it "does not render the Refresh tab" do
+      subject
+      expect(rendered).not_to have_link("Refresh", id: "name-refresh-tab")
+    end
+  end
+
+  context "when the user can edit the name" do
+    before { allow(view).to receive(:can?).with(:manage, Name).and_return(true) }
+
+    it "renders the Comment tab" do
+      subject
+      expect(rendered).to have_link("Comment", id: "name-comment-tab")
+    end
+
+    it "renders the Refresh tab" do
+      subject
+      expect(rendered).to have_link("Refresh", id: "name-refresh-tab")
+    end
+
+    context "and there are name tags" do
+      before { allow(NameTag).to receive(:all).and_return(double(count: 1)) }
+
+      it "renders the Tag tab" do
+        subject
+        expect(rendered).to have_link("Tag", id: "name-tags-tab")
+      end
+    end
+
+    context "and there are no name tags" do
+      it "does not render the Tag tab" do
+        subject
+        expect(rendered).not_to have_link("Tag", id: "name-tags-tab")
+      end
+    end
+  end
+
+  context "de-duplicate tab" do
+    context "when the name is a duplicate and user can update names" do
+      before do
+        allow(name).to receive(:duplicate?).and_return(true)
+        allow(view).to receive(:can?).with("names", "update").and_return(true)
+      end
+
+      it "renders the De-duplicate tab" do
+        subject
+        expect(rendered).to have_link("De-duplicate", id: "name-de-duplicate-tab")
+      end
+    end
+
+    context "when the name is a duplicate but user cannot update names" do
+      before do
+        allow(name).to receive(:duplicate?).and_return(true)
+      end
+
+      it "does not render the De-duplicate tab" do
+        subject
+        expect(rendered).not_to have_link("De-duplicate", id: "name-de-duplicate-tab")
+      end
+    end
+
+    context "when the name is not a duplicate" do
+      before do
+        allow(name).to receive(:duplicate?).and_return(false)
+        allow(view).to receive(:can?).with("names", "update").and_return(true)
+      end
+
+      it "does not render the De-duplicate tab" do
+        subject
+        expect(rendered).not_to have_link("De-duplicate", id: "name-de-duplicate-tab")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Gate the "More" tab and its sub-row (comments, tags, refresh) behind `can_edit_name?`, so users without name editing rights no longer see controls they cannot use. Previously the guard was `can?("names", "update")` which excluded `common-name` editors.
- Grant `common_name_editor` role access to `tab_tag`, `tab_more`, and all `name_tag_names` actions, enabling common-name editors to reach the tag and comment sub-tabs.
- Extract the duplicated name-edit permission check into a single `TabsHelper#can_edit_name?` helper, eliminating three copies of the same `can?(:manage, Name)` / `can?(:update_common_name)` logic spread across view partials.

## Type of change
New feature (backend permission + view gating) as part of a larger "More tab" work item (FLOR-221).

## Technical details
The old guard used the string-based `can?("names", "update")` check, which is only granted to `name_index_editor` and above. `common_name_editor` holds the symbol-based `can?(:update_common_name, name)` permission instead, so those users were silently locked out of the More tab. The new helper unifies both paths: full editors pass via `:manage, Name`; common-name editors pass when the name's type is literally "common".

## Test plan
- [x] Log in as a `common-name` editor, open a common name record — verify the "More" tab is visible and the Tag/Comment sub-tabs render correctly.
- [x] Log in as a `common-name` editor, open a scientific name record — verify the "More" tab is **not** shown.
- [x] Log in as a read-only / basic user — verify the "More" tab does not appear on any name.
- [x] Log in as a `name_index_editor` — verify the "More" tab, Comment, Tag, and Refresh sub-tabs all still render as before.
- [x] On a name with no tags (`NameTag.all.count == 0`), confirm the Tag sub-tab does not appear even for editors with access.

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
