### PR TITLE
FLOR-220 Add delete functionality for profile item annotations

### DIFF
--- a/app/controllers/profile_item_annotations_controller.rb
+++ b/app/controllers/profile_item_annotations_controller.rb
@@ -19,7 +19,7 @@
 class ProfileItemAnnotationsController < ApplicationController
   skip_before_action :authorise
 
-  before_action :set_profile_item_annotation, only: %i[update]
+  before_action :set_profile_item_annotation, only: %i[update destroy]
 
   before_action :authorise_user!, except: [:create]
 
@@ -49,6 +49,16 @@ class ProfileItemAnnotationsController < ApplicationController
     really_update if changed?
   end
 
+  def destroy
+    @profile_item = @profile_item_annotation.profile_item
+    @profile_item_annotation.destroy!
+    @message = "Deleted"
+    render :delete
+  rescue StandardError => e
+    @message = e.to_s
+    render :update_failed, status: :unprocessable_content
+  end
+
   private
 
   def authorise_user!
@@ -64,15 +74,12 @@ class ProfileItemAnnotationsController < ApplicationController
   end
 
   def really_update
-    if permitted_params[:value].blank?
-      @profile_item_annotation.destroy!
-      @message = "Deleted"
-      render :delete
-    elsif @profile_item_annotation.update(permitted_params.merge(updated_by: current_user.username))
+    if @profile_item_annotation.update(permitted_params.merge(updated_by: current_user.username))
       @message = "Updated"
       render :update
     else
-      raise("Not updated")
+      @message = @profile_item_annotation.errors.full_messages.join(", ")
+      render :update_failed, status: :unprocessable_content
     end
   rescue StandardError => e
     @message = e.to_s

--- a/app/javascript/cancel_link_click.js
+++ b/app/javascript/cancel_link_click.js
@@ -18,6 +18,9 @@
     debug(`data-enable-this-id: ${$element.attr('data-enable-this-id')}`);
     $(`#${$element.attr('data-hide-this-id')}`).addClass('hidden');
     $(`#${$element.attr('data-enable-this-id')}`).removeClass('disabled');
+    if ($element.attr('data-show-this-id')) {
+      $(`#${$element.attr('data-show-this-id')}`).removeClass('hidden');
+    }
     $(`.${$element.attr('data-empty-this-class')}`).html('');
     $('.message-container').html('');
     $('.error-container').html('');

--- a/app/javascript/unconfirmed_action_link_click.js
+++ b/app/javascript/unconfirmed_action_link_click.js
@@ -15,6 +15,9 @@
   unconfirmedActionLinkClick = function(event, $element) {
     debug('unconfirmedActionLinkClick');
     $(`#${$element.attr('data-show-this-id')}`).removeClass('hidden');
+    if ($element.attr('data-hide-this-id')) {
+      $(`#${$element.attr('data-hide-this-id')}`).addClass('hidden');
+    }
     $element.addClass('disabled');
     $('.message-container').html('');
     return event.preventDefault();

--- a/app/views/instances/tabs/_tab_profile_v2.html.erb
+++ b/app/views/instances/tabs/_tab_profile_v2.html.erb
@@ -111,6 +111,7 @@
 
         <div id="profile_item_actions_<%= product_item_config.id %>">
           <% if profile_item.persisted? %>
+            <%= divider %>
             <% if profile_item.allow_delete? %>
               <%= render partial: "profile_items/delete_widgets", locals: {profile_item: profile_item} %>
             <% else %>

--- a/app/views/profile_item_annotations/_delete_widgets.html.erb
+++ b/app/views/profile_item_annotations/_delete_widgets.html.erb
@@ -1,0 +1,35 @@
+<div style="margin-top: 6px; text-align: right;">
+  <%= link_to "Delete annotation",
+      '#',
+      id: "annotation-delete-link-#{profile_item_annotation.id}",
+      class: "btn btn-default btn-xs unconfirmed-delete-link",
+      title: "Delete this annotation. A confirmation step follows.",
+      data: {
+        show_this_id: "confirm-or-cancel-annotation-container-#{profile_item_annotation.id}",
+        hide_this_id: "annotation-delete-link-#{profile_item_annotation.id}",
+      }
+  %>
+  <span id="confirm-or-cancel-annotation-container-<%= profile_item_annotation.id %>"
+        class="hidden">
+    <span style="font-size: 0.9em; color: #555; vertical-align: middle;">Delete annotation?</span>
+    &nbsp;
+    <%= link_to "Confirm delete",
+        profile_item_annotation_path(profile_item_annotation),
+        class: "btn btn-danger btn-xs confirm-delete-btn",
+        title: "Select to confirm the delete.",
+        data: {
+          turbo_method: :delete,
+          turbo_stream: true
+        } %>
+    &nbsp;
+    <%= link_to "Cancel delete",
+        '#',
+        title: "Select to cancel the delete.",
+        class: "btn btn-default btn-xs cancel-link",
+        data: {
+          hide_this_id: "confirm-or-cancel-annotation-container-#{profile_item_annotation.id}",
+          show_this_id: "annotation-delete-link-#{profile_item_annotation.id}",
+          enable_this_id: "annotation-delete-link-#{profile_item_annotation.id}",
+        } %>
+  </span>
+</div>

--- a/app/views/profile_item_annotations/_form.html.erb
+++ b/app/views/profile_item_annotations/_form.html.erb
@@ -1,13 +1,14 @@
 <%= form_with url: url, method: method, remote: true, html: { class: "prompt-form-save", data: { type: :json, form_type: 'annotation_form' } } do |f| %>
-  <div style="margin-top: 10px; display: flex; align-items: center;">
-    <!-- Hidden fields with parameters -->
+  <div style="margin-top: 10px; display: flex; align-items: flex-start; gap: 8px;">
     <%= hidden_field_tag "profile_item_annotation[profile_item_id]", profile_item_annotation.profile_item_id %>
-
-    <!-- Text area for annotation input -->
-    <%= text_area_tag "profile_item_annotation[value]", profile_item_annotation.value, placeholder: "Enter text here...", rows: 2, style: 'flex-grow: 1; padding: 5px; border: 1px solid #ccc; border-radius: 4px; background-color: white; min-height: 50px; resize: vertical;' %>
-
-    <!-- Submit button -->
-    <%= f.submit 'Save', style: 'background-color: #5a5a5a; color: white; border: none; padding: 5px 10px; cursor: pointer; border-radius: 4px; margin-left: 10px;' %>
+    <div style="flex: 1;">
+      <%= text_area_tag "profile_item_annotation[value]", profile_item_annotation.value, placeholder: "Enter text here...", rows: 2, style: 'width: 100%; padding: 5px; border: 1px solid #ccc; border-radius: 4px; background-color: white; min-height: 50px; resize: vertical;' %>
+      <% if profile_item_annotation.persisted? %>
+        <%= render partial: "profile_item_annotations/delete_widgets",
+            locals: { profile_item_annotation: profile_item_annotation } %>
+      <% end %>
+    </div>
+    <%= f.submit 'Save', style: 'background-color: #5a5a5a; color: white; border: none; padding: 5px 10px; cursor: pointer; border-radius: 4px; flex-shrink: 0;' %>
   </div>
 <% end %>
 <script>

--- a/app/views/profile_items/_edit_tab_profile_item.html.erb
+++ b/app/views/profile_items/_edit_tab_profile_item.html.erb
@@ -25,6 +25,7 @@
   <% end %>
 
   <div id="profile_item_actions_<%= product_item_config.id %>">
+    <%= divider %>
     <% if profile_item.allow_delete? %>
       <%= render partial: "profile_items/delete_widgets", locals: {profile_item: profile_item, non_turbo: true} %>
     <% else %>

--- a/app/views/profile_items/_fact_profile_item.html.erb
+++ b/app/views/profile_items/_fact_profile_item.html.erb
@@ -101,6 +101,7 @@
     </div>
 
     <div id="profile_item_actions_<%= product_item_config.id %>">
+      <%= divider %>
       <% if profile_item.persisted? %>
         <% if profile_item.allow_delete?%>
           <%= render partial: "profile_items/delete_widgets", locals: {profile_item: profile_item} %>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,9 @@
 - :date: 22-May-2026
+  :jira_id: '220'
+  :jira_project: FLOR
+  :description: |-
+    Add a delete button for profile item annotations
+- :date: 22-May-2026
   :jira_id: '221'
   :jira_project: FLOR
   :description: |-

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
         defaults: { tab: "tab_show_1" }
 
   resources :profile_texts, only: %i[create update]
-  resources :profile_item_annotations, only: %i[create update]
+  resources :profile_item_annotations, only: %i[create update destroy]
   resources :profile_item_references, only: %i[create]
   resources :profile_items, only: %i[destroy index] do
     member do

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.10
+appversion=5.1.3.11

--- a/spec/controllers/profile_item_annotations_controller_spec.rb
+++ b/spec/controllers/profile_item_annotations_controller_spec.rb
@@ -80,12 +80,14 @@ RSpec.describe ProfileItemAnnotationsController, type: :controller do
     end
 
     context "when value is blank" do
-      it "destroys the profile_item_annotation and renders :delete" do
-        put :update, params: { id: profile_item_annotation.id, profile_item_annotation: { value: "" } }, format: :turbo_stream
+      it "does not destroy the annotation and renders :update_failed with a validation error" do
+        expect {
+          put :update, params: { id: profile_item_annotation.id, profile_item_annotation: { value: "" } }, format: :turbo_stream
+        }.not_to change(Profile::ProfileItemAnnotation, :count)
 
-        expect(assigns(:message)).to eq("Deleted")
-        expect { profile_item_annotation.reload }.to raise_error(ActiveRecord::RecordNotFound)
-        expect(response).to render_template(:delete)
+        expect(assigns(:message)).to include("can't be blank")
+        expect(response).to render_template(:update_failed)
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
@@ -120,6 +122,51 @@ RSpec.describe ProfileItemAnnotationsController, type: :controller do
         expect(assigns(:message)).to eq("Update failed")
         expect(response).to render_template(:update_failed)
         expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    let!(:profile_item_annotation) { FactoryBot.create(:profile_item_annotation, profile_item: profile_item, value: "To be deleted") }
+
+    context "for authorized user" do
+      before do
+        allow(controller).to receive(:can?).with(:manage, profile_item_annotation).and_return(true)
+      end
+
+      it "destroys the profile_item_annotation and renders :delete" do
+        expect {
+          delete :destroy, params: { id: profile_item_annotation.id }, format: :turbo_stream
+        }.to change(Profile::ProfileItemAnnotation, :count).by(-1)
+
+        expect(assigns(:message)).to eq("Deleted")
+        expect(response).to render_template(:delete)
+        expect(response.media_type).to eq("text/vnd.turbo-stream.html")
+      end
+
+      context "when an error occurs during destroy" do
+        before do
+          allow_any_instance_of(Profile::ProfileItemAnnotation).to receive(:destroy!).and_raise(StandardError, "Destroy failed")
+        end
+
+        it "renders :update_failed with an error message" do
+          delete :destroy, params: { id: profile_item_annotation.id }, format: :turbo_stream
+
+          expect(assigns(:message)).to eq("Destroy failed")
+          expect(response).to render_template(:update_failed)
+          expect(response).to have_http_status(:unprocessable_content)
+        end
+      end
+    end
+
+    context "for non-authorized user" do
+      before do
+        allow(controller).to receive(:can?).with(:manage, profile_item_annotation).and_return(false)
+      end
+
+      it "is forbidden access" do
+        delete :destroy, params: { id: profile_item_annotation.id }, format: :turbo_stream
+        expect(response).to have_http_status(:forbidden)
       end
     end
   end

--- a/test/controllers/profile_item_annotations_controller_test.rb
+++ b/test/controllers/profile_item_annotations_controller_test.rb
@@ -92,8 +92,38 @@ class ProfileItemAnnotationsControllerTest < ActionController::TestCase
 
       assert_response :unprocessable_content
       assert_equal profile_item_annotation.id, assigns(:profile_item_annotation).id
-      assert_match "Not updated", assigns(:message)
       assert_template :update_failed
     end
+  end
+
+  test "should return validation error when update value is blank" do
+    profile_item = profile_item(:ecology_pi)
+    profile_item_annotation = profile_item.profile_item_annotation
+
+    put :update, params: {
+      id: profile_item_annotation.id,
+      profile_item_annotation: {
+        value: ""
+      }
+    }, session: @session, xhr: true
+
+    assert_response :unprocessable_content
+    assert_match "can't be blank", assigns(:message)
+    assert_template :update_failed
+    assert profile_item_annotation.reload.value.present?
+  end
+
+  test "should destroy profile item annotation" do
+    profile_item = profile_item(:ecology_pi)
+    profile_item_annotation = profile_item.profile_item_annotation
+
+    assert_difference("Profile::ProfileItemAnnotation.count", -1) do
+      delete :destroy, params: { id: profile_item_annotation.id },
+             session: @session, xhr: true
+    end
+
+    assert_response :success
+    assert_equal "Deleted", assigns(:message)
+    assert_template :delete
   end
 end


### PR DESCRIPTION
## Summary

  - Adds a proper destroy action for profile item annotations so users can explicitly delete an annotation via a two-step confirm/cancel UI, rather than the previous implicit behaviour where saving with a blank value silently deleted the record
  - Clearing the annotation textarea and saving now shows a validation error ("Value can't be blank") instead of destroying the record, making save and delete distinct, intentional operations
  - Extracts the delete workflow into a `_delete_widgets` partial consistent with how profile item and reference deletes are organised
  - Extends `unconfirmed_action_link_click.js` and `cancel_link_click.js` with optional `data-hide-this-id` / `data-show-this-id` support so the trigger button hides itself when the confirm row appears and is fully restored (visible + enabled) on cancel

## Type of change
  New feature — adds an explicit delete flow for profile item annotations with supporting UI and backend changes.

## Technical details
  The original controller used a "blank value = delete" shortcut in `really_update`, bypassing the model's `validates :value, presence: true`. The destroy action is now a first-class route (`DELETE /profile_item_annotations/:id`) that reuses the existing `delete.turbo_stream.erb` response. The JS changes are backward-compatible: the new `data-hide-this-id` on the unconfirmed handler and `data-show-this-id` on the cancel handler are opt-in — existing delete widgets that don't set those attributes are unaffected.

## Test plan

  - [x] Open a profile item with an existing annotation — confirm the "Delete annotation" button appears below the textarea
  - [x] Click "Delete annotation" — confirm the button hides and the "Delete annotation? Confirm delete / Cancel delete" row appears in its
  place
  - [x] Click "Cancel delete" — confirm the confirm row disappears and the "Delete annotation" button is restored (visible and clickable)
  - [x] Click "Delete annotation" then "Confirm delete" — confirm the annotation is removed and the form resets to the empty "create new
  annotation" state
  - [x] Clear the annotation textarea and click "Save" — confirm a validation error is shown and the annotation record is not deleted
  - [x] Verify the delete workflow on all three surfaces where annotations appear: fact profile item, linked profile item, and the v2 tab
  profile
## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
