### PR TITLE
FLOR-215: Restrict draft-profile-editor manage_profile to product-matched instances

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -63,7 +63,7 @@ class Ability
     reviewer_auth(user) if user.with_role?('tree-reviewer')
     draft_editor(user) if user.with_role?('draft-editor') && not_name_index
     profile_editor(user) if user.with_role?('profile-editor') && not_name_index
-    draft_profile_editor if user.with_role?('draft-profile-editor') && not_name_index
+    draft_profile_editor(user) if user.with_role?('draft-profile-editor') && not_name_index
     profile_reference_auth(user) if user.with_role?('profile-reference') && not_name_index
     tree_builder_auth(user) if user.with_role?('tree-builder')
     tree_publisher_auth(user) if user.with_role?('tree-publisher')
@@ -84,10 +84,10 @@ class Ability
     @user.id
   end
 
-  def draft_profile_editor
+  def draft_profile_editor(user)
     can :manage, :profile_v2
     can :manage_profile, Instance do |instance|
-      instance.draft?
+      instance.draft? && instance.profile_items.includes([:product]).any? { |item| item.product && item.product == user.product_from_context }
     end
     can [:create, :read], Author
     can :update, Author do |author|

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,8 @@
+- :date: 26-May-2026
+  :jira_id: '215'
+  :jira_project: FLOR
+  :description: |-
+    Fixup draft-profile-editor permissions to only allow managing profile items that are related to the product
 - :date: 25-May-2026
   :jira_id: '220'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.13
+appversion=5.1.3.14

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -112,9 +112,21 @@ RSpec.describe Ability, type: :model do
       end
     end
 
-    it 'can manage draft instances' do
+    it 'can manage draft instances with matching product profile items' do
       instance = create(:instance, draft: true)
+      profile_item = double('profile_item', product: product)
+      profile_items_relation = double('profile_items_relation')
+      allow(profile_items_relation).to receive(:includes).with([:product]).and_return([profile_item])
+      allow(instance).to receive(:profile_items).and_return(profile_items_relation)
       expect(subject.can?(:manage_profile, instance)).to eq true
+    end
+
+    it 'cannot manage draft instances without matching product profile items' do
+      instance = create(:instance, draft: true)
+      profile_items_relation = double('profile_items_relation')
+      allow(profile_items_relation).to receive(:includes).with([:product]).and_return([])
+      allow(instance).to receive(:profile_items).and_return(profile_items_relation)
+      expect(subject.can?(:manage_profile, instance)).to eq false
     end
 
     it 'cannot manage non-draft instances' do


### PR DESCRIPTION
## Summary
- `draft-profile-editor` users can now only manage profile on instances that have at least one profile item belonging to their product context — previously any draft instance was manageable, allowing cross-product access
- Pass `user` to `draft_profile_editor` so the method can apply product-scoped checks (it was previously called without arguments, making user context inaccessible inside the method)

## Type of change
  Bug fix / security tightening — closes an authorization gap where draft-profile-editors could manage profile on any draft instance regardless of product ownership.

## Technical details
  The `manage_profile` block now checks `instance.profile_items.includes([:product]).any? { |item| item.product && item.product == user.product_from_context }` in addition to `instance.draft?`. The `includes([:product])` eager-loads the product through `product_item_config` to avoid N+1 queries in the block.

Specs mock `profile_items` at the relation level (rather than creating real DB records) to avoid a pre-existing `StaleObjectError` on `Profile::ProfileObjectType` that affects all tests that create profile items within a transaction.

## Test plan
  - [x] Log in as a `draft-profile-editor` user for Product A; open an instance that only has profile items for Product B — the manage-profile action should be denied
  - [x] Log in as a `draft-profile-editor` user for Product A; open a draft instance that has a profile item for Product A — manage-profile should be allowed
  - [x] Verify non-draft instances remain inaccessible to `draft-profile-editor` regardless of product match
  - [x] Confirm `profile-editor` and `draft-editor` roles are unaffected

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
