### PR TITLE
 FLOR-216: Restrict product admins from updating user records

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -563,6 +563,7 @@ class Ability
   def product_admin_auth(session_user)
     # Product admins have all standard admin permissions
     admin_auth
+    cannot "users", "update"
 
     # NOTES: But they can only manage user product roles for products they have admin access to
     # For product admin functionality, we need a User record since that's where roles are stored

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,9 @@
 - :date: 27-May-2026
+  :jira_id: '216'
+  :jira_project: FLOR
+  :description: |-
+    Restrict product admins from updating user details
+- :date: 27-May-2026
   :jira_id: '5635'
   :description: |-
     Batch Loader: Allow manual addition of unsourced misapplications to an accepted or excluded name directly in a batch

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.15
+appversion=5.1.3.16

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -1846,7 +1846,12 @@ RSpec.describe Ability, type: :model do
       it "inherits all standard admin permissions" do
         expect(subject.can?("admin", :all)).to eq true
         expect(subject.can?("menu", "admin")).to eq true
-        expect(subject.can?("users", :all)).to eq true
+      end
+
+      it "allows viewing users but not updating them" do
+        expect(subject.can?("users", "index")).to eq true
+        expect(subject.can?("users", "show")).to eq true
+        expect(subject.can?("users", "update")).to eq false
       end
     end
 


### PR DESCRIPTION
## Summary
- Product admins can no longer update user records (users#update), preventing them from modifying user details beyond their intended scope of managing product roles only.

## Type of change
improvement / permission hardening — product admin role had broader access to user management than intended.

## Technical details
product_admin_auth calls admin_auth first (which grants can "users", :all), then immediately overrides with cannot "users", "update".  CanCanCan evaluates rules in order and the last matching rule wins, so placing the cannot after admin_auth correctly narrows the inherited permission.

## Test plan
  - [x] Log in as a product admin (user with an admin product role but no AD admin group membership) and verify the user edit/update action is inaccessible (403 or hidden UI).
  - [x] Confirm the product admin can still view the users list (users#index) and individual user records (users#show).
  - [x] Confirm a full AD admin (not product admin) can still update user records — their permissions should be unaffected.
  - [x] Confirm product admins can still manage user product roles for their own products (the user/product_roles actions remain permitted).

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
