### PR TITLE
FLOR-217 Add current_version? method and improve print preview for pr…

### DIFF
--- a/app/models/profile/profile_item.rb
+++ b/app/models/profile/profile_item.rb
@@ -109,6 +109,10 @@ module Profile
       is_draft? && !instance.draft?
     end
 
+    def current_version?
+      !draft_version? && published_date.present? && end_date.nil?
+    end
+
     private
 
     def conditionally_destroy_profile_text

--- a/app/views/application/search_results/print/records/_profile_item.html.erb
+++ b/app/views/application/search_results/print/records/_profile_item.html.erb
@@ -1,39 +1,48 @@
 
-<tr class="search-result profile-item">
-  <td class="width-1-percent"></td>
-  <td class="text profile-item main-content" colspan="5">
-    <div class="profile-item-content">
-      <% if search_result.product_item_config.present? %>
-        <h3 class="profile-item-header"><strong><%= search_result.product_item_config.display_html %></strong></h3>
-      <% end %>
-      <% if search_result.profile_text.present? %>
-        <div class="profile-text" style="margin-top: 5px;">
-          <%= markdown_to_html(search_result.profile_text.value_md.to_s) %>
-        </div>
-      <% end %>
-      <% if search_result.profile_item_references.present? %>
-        <div class="profile-references" style="margin-top: 10px;">
-          <strong>References:</strong>
-          <% search_result.profile_item_references.each do |pir| %>
-            <div style="margin-left: 15px;">
-              <%= pir.reference.citation if pir.reference %>
-              <%= display_pages(pir.reference.pages) if pir.reference %>
-              <% if pir.annotation.present? %>
-                <br><em><%= pir.annotation %></em>
-              <% end %>
-            </div>
-          <% end %>
-        </div>
-      <% end %>
-      <% if search_result.profile_item_annotation.present? %>
-        <div class="profile-annotation" style="margin-top: 10px;">
-          <strong>Annotation:</strong>
-          <div style="margin-left: 15px;">
-            <%= markdown_to_html(search_result.profile_item_annotation.value.to_s) %>
+<% unless search_result.end_date %>
+  <tr class="search-result profile-item">
+    <td class="width-1-percent"></td>
+    <td class="text profile-item main-content" colspan="5">
+      <div class="profile-item-content">
+        <% if search_result.product_item_config.present? %>
+          <h3 class="profile-item-header">
+            <strong><%= search_result.product_item_config.display_html %></strong>
+            <% if search_result.is_draft?%>
+              <em>(Draft)</em>
+            <% end %>
+            <% if search_result.current_version? %>
+              <em>(Current)</em>
+            <% end %>
+          </h3>
+        <% end %>
+        <% if search_result.profile_text.present? %>
+          <div class="profile-text" style="margin-top: 5px;">
+            <%= markdown_to_html(search_result.profile_text.value_md.to_s) %>
           </div>
-        </div>
-      <% end %>
-    </div>
-  </td>
-</tr>
-
+        <% end %>
+        <% if search_result.profile_item_references.present? %>
+          <div class="profile-references" style="margin-top: 10px;">
+            <strong>References:</strong>
+            <% search_result.profile_item_references.each do |pir| %>
+              <div style="margin-left: 15px;">
+                <%= pir.reference.citation if pir.reference %>
+                <%= display_pages(pir.reference.pages) if pir.reference %>
+                <% if pir.annotation.present? %>
+                  <br><em><%= pir.annotation %></em>
+                <% end %>
+              </div>
+            <% end %>
+          </div>
+        <% end %>
+        <% if search_result.profile_item_annotation.present? %>
+          <div class="profile-annotation" style="margin-top: 10px;">
+            <strong>Annotation:</strong>
+            <div style="margin-left: 15px;">
+              <%= markdown_to_html(search_result.profile_item_annotation.value.to_s) %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </td>
+  </tr>
+<% end %>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,9 @@
 - :date: 27-May-2026
+  :jira_id: '217'
+  :jira_project: FLOR
+  :description: |-
+    Improve the print preview of profile items by adding draft/current labels and removing ended items
+- :date: 27-May-2026
   :jira_id: '216'
   :jira_project: FLOR
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.16
+appversion=5.1.3.17

--- a/spec/models/profile/profile_item_spec.rb
+++ b/spec/models/profile/profile_item_spec.rb
@@ -210,6 +210,41 @@ RSpec.describe Profile::ProfileItem, type: :model do
     end
   end
 
+  describe "#current_version?" do
+    let(:instance) { create(:instance, draft: false) }
+    let(:profile_item) { create(:profile_item, instance:, is_draft: false, published_date: Time.current, end_date: nil) }
+
+    subject { profile_item.current_version? }
+
+    it "returns true when not a draft version, has a published_date, and end_date is nil" do
+      expect(subject).to be true
+    end
+
+    context "when the profile item is a draft version" do
+      before { profile_item.update(is_draft: true) }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "when published_date is nil" do
+      before { profile_item.update(published_date: nil) }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+
+    context "when end_date is present" do
+      before { profile_item.update(end_date: Time.current) }
+
+      it "returns false" do
+        expect(subject).to be false
+      end
+    end
+  end
+
   describe "after_destroy callback" do
     let(:profile_text) { create(:profile_text) }
     let(:profile_item) { create(:profile_item, profile_text: profile_text, statement_type: statement_type) }

--- a/test/factories/profile_object_type.rb
+++ b/test/factories/profile_object_type.rb
@@ -24,7 +24,6 @@ FactoryBot.define do
     name { "Sample Name" }
     rdf_id { "text" }
     is_deprecated { true }
-    lock_version { 1 }
     created_by { "Sample Created by" }
     updated_by { "Sample Updated by" }
     api_name { "Sample Api name" }


### PR DESCRIPTION
## Summary
- Filter out end-dated profile items from the print preview so only active items are shown; add "(Draft)" and "(Current)" labels to help distinguish item states at a glance
- Add `current_version?` helper to `Profile::ProfileItem` to identify items that are published, not draft, and not superseded (no end date)

## Type of change
Feature improvement (print preview labels and filtering)

## Test plan
  - [x] Open a name's print preview with a mix of active, draft, and end-dated profile items — confirm end-dated items are hidden, draft items show "(Draft)", and published-current items show "(Current)"

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
