### PR TITLE
FLOR-218: Fix versioned update success message not showing after dropdown selection

### DIFF
--- a/app/views/profile_items/_product_item_config_container.html.erb
+++ b/app/views/profile_items/_product_item_config_container.html.erb
@@ -13,7 +13,7 @@
   <% end %>
 </div>
 
-<div class="product-item-config-container product-item-config-container-id-<%= product_item_config.id %>">
+<div id="edit-tab-profile-item" class="product-item-config-container product-item-config-container-id-<%= product_item_config.id %>">
   <% if profile_item.fact? %>
     <%= render(
       partial: "profile_items/fact_profile_item",

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,8 @@
+- :date: 28-May-2026
+  :jira_id: '218'
+  :jira_project: FLOR
+  :description: |-
+    Fixup the ui for of the versioned update success message
 - :date: 27-May-2026
   :jira_id: '217'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.17
+appversion=5.1.3.18


### PR DESCRIPTION
## Summary
- Fix the \"Create a Versioned Update\" success message (with refresh button) not appearing after clicking the button — the turbo stream response was targeting a DOM element (`edit-tab-profile-item`) that no longer existed after the dropdown UI re-rendered the profile item container

## Type of change

Bug fix.

## Technical details

The success turbo stream (`create.turbo_stream.erb`) targets `id="edit-tab-profile-item"` to display the confirmation alert. This ID is present on initial page load via `_tab_product_config_profile_item_form.html.erb`, but when the user selects from the product item config dropdown, `index.turbo_stream.erb` re-renders the container using `_product_item_config_container.html.erb` — which was missing that ID. Adding the ID to the container div in that partial ensures the target always exists regardless of how the profile item section was loaded.

## Test plan

- [x] On the Profile tab of a standalone instance, select a profile item type from the dropdown (e.g. "Etymology - Existing (Edit)") and click "Create a Versioned Update" — confirm the green success alert and "Refresh to view the new version" button appear
- [x] Confirm the same works on initial page load (without changing the dropdown) if a config is pre-selected
- [x] Confirm the "Refresh to view the new version" button correctly reloads the profile section showing the new draft version
