### PR TITLE
Nsl 5811 add synonym creation to draft instance name change

### DIFF
--- a/app/controllers/instances/change_name_controller.rb
+++ b/app/controllers/instances/change_name_controller.rb
@@ -21,22 +21,34 @@ class Instances::ChangeNameController < ApplicationController
 
   def update
     new_name_id = params[:instance]&.fetch(:name_id, nil)
+
     if new_name_id.blank?
       @message = "Please select a name."
       return render("instances/change_name_error", status: :unprocessable_content)
     end
+
+    if synonym_creation_requested? && (missing = missing_synonym_fields).any?
+      @message = "Please enter #{missing.join(" and ")} to add this name as a synonym."
+      return render("instances/change_name_error", status: :unprocessable_content)
+    end
+
     service = Instances::ChangeNameService.call(
       instance: @instance,
       new_name_id: new_name_id.to_i,
-      username: current_user.username
+      username: current_user.username,
+      create_synonym: synonym_creation_requested?,
+      cites_id: params[:instance][:cites_id],
+      synonym_instance_type_id: params[:instance][:synonym_instance_type_id]
     )
+
     if service.errors.any?
       @message = service.errors.full_messages.join(", ")
       return render("instances/change_name_error", status: :unprocessable_content)
     end
+
     @message = "Name updated"
     render("instances/change_name")
-  rescue StandardError => e
+  rescue => e
     @message = e.to_s
     render("instances/change_name_error", status: :unprocessable_content)
   end
@@ -46,12 +58,23 @@ class Instances::ChangeNameController < ApplicationController
       term: params[:term],
       name_type_id: @instance.name.name_type_id,
       name_rank_id: @instance.name.name_rank_id,
-      exclude_name_id: @instance.name_id,
+      exclude_name_id: @instance.name_id
     )
     render(json: typeahead.suggestions)
   end
 
   private
+
+  def synonym_creation_requested?
+    params[:instance]&.fetch(:create_synonym, nil) == "yes"
+  end
+
+  def missing_synonym_fields
+    fields = []
+    fields << "an instance (the name and optional year)" if params[:instance][:cites_id].blank?
+    fields << "a type" if params[:instance][:synonym_instance_type_id].blank?
+    fields
+  end
 
   def find_instance
     @instance = Instance.find(params[:instance_id])

--- a/app/javascript/typeaheads/for_instance/synonymy.js
+++ b/app/javascript/typeaheads/for_instance/synonymy.js
@@ -38,3 +38,46 @@ window.instanceForSynonymy = new Bloodhound({
 window.instanceForSynonymy.initialize();
 
 window.instanceForSynonymy = instanceForSynonymy;
+
+// Dedicated setup for the change-name form's synonym typeahead.
+// Uses change-name-specific ids so it does not collide with the
+// synonymy tab (_tab_synonymy_for_profile_v2), which shares the generic
+// `instance-instance-for-name-showing-reference-typeahead`/`instance_cites_id` ids.
+function setUpChangeNameSynonymyInstance() {
+    $('#change-name-synonymy-typeahead').typeahead({highlight: true}, {
+        name: 'change-name-synonymy-typeahead',
+        displayKey: 'value',
+        source: instanceForChangeNameSynonymy.ttAdapter()})
+        .on('typeahead:selected', function($e,datum) {
+            $('#change-name-synonymy-cites-id').val(datum.id);
+        })
+        .on('typeahead:autocompleted', function($e,datum) {
+            $('#change-name-synonymy-cites-id').val(datum.id);
+        })
+        .on('typeahead:closed', function($e,datum) {
+            // NOOP: cannot distinguish tabbing through vs emptying vs typing text.
+            // Users must select or autocomplete.
+        });
+}
+
+window.setUpChangeNameSynonymyInstance = setUpChangeNameSynonymyInstance;
+
+// Bloodhound for the change-name form, keyed off the change-name-specific
+// current-name hidden field.
+window.instanceForChangeNameSynonymy = new Bloodhound({
+    datumTokenizer: Bloodhound.tokenizers.obj.whitespace('value'),
+    queryTokenizer: Bloodhound.tokenizers.whitespace,
+    remote: {url: window.relative_url_root + '/instances/for_synonymy?term=%QUERY',
+        replace: function(url,query) {
+            return window.relative_url_root + '/instances/for_synonymy?name_id=' +
+                $('#change-name-current-name-id').val() +
+                '&term=' + encodeURIComponent(query) + '&' +
+                'cache_buster=' + Math.floor((Math.random() * 1000) + 1).toString()
+        }
+    },
+    limit: 100
+});
+
+window.instanceForChangeNameSynonymy.initialize();
+
+window.instanceForChangeNameSynonymy = instanceForChangeNameSynonymy;

--- a/app/services/instances/change_name_service.rb
+++ b/app/services/instances/change_name_service.rb
@@ -1,14 +1,33 @@
 # frozen_string_literal: true
+
 module Instances
   class ChangeNameService < BaseService
-    def initialize(instance:, new_name_id:, username:)
+    def initialize(instance:, new_name_id:, username:,
+      create_synonym: false, cites_id: nil, synonym_instance_type_id: nil)
       super({})
       @instance = instance
       @new_name_id = new_name_id.to_i
       @username = username
+      @create_synonym = create_synonym
+      @cites_id = cites_id
+      @synonym_instance_type_id = synonym_instance_type_id
     end
 
     def execute
+      ActiveRecord::Base.transaction do
+        change_name
+        create_synonym_instance if errors.none? && create_synonym?
+        raise ActiveRecord::Rollback if errors.any?
+      end
+    end
+
+    private
+
+    def create_synonym?
+      @create_synonym.to_s == "yes" || @create_synonym == true
+    end
+
+    def change_name
       new_name = Name.find(@new_name_id)
 
       if synonym_name_ids.include?(@new_name_id)
@@ -16,7 +35,7 @@ module Instances
       end
 
       unless new_name.name_type_id == @instance.name.name_type_id &&
-             new_name.name_rank_id == @instance.name.name_rank_id
+          new_name.name_rank_id == @instance.name.name_rank_id
         return errors.add(:base, "The selected name must be the same type and rank as the current name.")
       end
 
@@ -27,7 +46,30 @@ module Instances
       errors.merge!(@instance.errors) if @instance.errors.any?
     end
 
-    private
+    # Add the selected name back as a synonym, citing the instance the user
+    # chose. Mirrors the cites/cited_by shape built by
+    # InstancesController#create_cites_and_cited_by -> #build_them:
+    #   name_id      = cites.name.id
+    #   cites_id     = cites.id
+    #   cited_by_id  = cited_by.id          (this instance)
+    #   reference_id = cited_by.reference.id
+    # draft and the override flags fall through to their model defaults, exactly
+    # as the controller path does for this form.
+    def create_synonym_instance
+      cites = Instance.find(@cites_id)
+      synonym = Instance.new(
+        name_id: cites.name_id,
+        cites_id: cites.id,
+        cited_by_id: @instance.id,
+        reference_id: @instance.reference_id,
+        instance_type_id: @synonym_instance_type_id
+      )
+      synonym.save_with_username(@username)
+    rescue ActiveRecord::RecordInvalid => e
+      errors.add(:base, e.record.errors.full_messages.join(", "))
+    rescue ActiveRecord::RecordNotUnique
+      errors.add(:base, "A matching synonym already exists for this instance.")
+    end
 
     def synonym_name_ids
       Instance.where(cited_by_id: @instance.id).where.not(cites_id: nil).pluck(:name_id)

--- a/app/views/instances/_form_change_name.html.erb
+++ b/app/views/instances/_form_change_name.html.erb
@@ -1,5 +1,5 @@
-<br/>
-<p>Change the name for this draft instance.</p>
+<%= divider %>
+<div>Change the name for this draft instance.</div>
 <%= form_for(@instance,
              url: instance_name_path(@instance),
              html: { id: "change-name-form", method: :patch, remote: true }) do |f| %>
@@ -10,13 +10,83 @@
          tabindex="<%= increment_tab_index %>"
          title="Enter a name. Must be same type and rank as the current name."
          type="text"
-         value="<%= @instance.name.try('full_name') %>"/>
+         value=""/>
   <%= hidden_field_tag "instance[name_id]", "", id: "instance-change-name-id" %>
   <script>setUpInstanceNameChange(<%= @instance.id %>);</script>
+  <div>
+    <br/>
+    <div>The name <%= @instance.name.try('full_name') %> will be added as a synonym to this instance.</div>
+    <select id="synonym-creation-select"
+            name="instance[create_synonym]"
+            title="Select whether the new name will be added as a synonym"
+            tabindex="<%= increment_tab_index %>">
+      <option value="yes">Yes</option>
+      <option value="no">No</option>
+    </select>
+
+    <div id="synonym-creation-fields" style="margin-top: 10px;">
+      <div><%= @instance.name.try('full_name') %> (and optional year)*, as referenced below:</div>
+      <div class="typeahead-container">
+        <section class='block width-100-percent'>
+          <input id="change-name-synonymy-typeahead"
+                 class="typeahead form-control width-100-percent"
+                 title="Enter an instance. Typeahead field on name and year. Only names with instances are listed."
+                 tabindex="<%= increment_tab_index %>"
+                 type="text"
+                 placeholder="Name typeahead to list instances, 4 consecutive digits treated as a year"
+                 value=""/>
+        </section>
+      </div>
+      <%= hidden_field_tag "instance[cites_id]", "", id: "change-name-synonymy-cites-id" %>
+      <%= hidden_field_tag "change_name_current_name_id", @instance.name_id, id: "change-name-current-name-id" %>
+      is a type*
+      <br>
+      <%= select_tag "instance[synonym_instance_type_id]",
+                     options_for_select(InstanceType.synonym_options),
+                     include_blank: true,
+                     class: "form-control width-50-percent",
+                     title: "Select instance type",
+                     tabindex: increment_tab_index %>
+    </div>
+    <script>
+      setUpChangeNameSynonymyInstance();
+      $('#synonym-creation-select').on('change', function() {
+        if ($(this).val() === 'yes') {
+          $('#synonym-creation-fields').show();
+        } else {
+          $('#synonym-creation-fields').hide();
+        }
+      });
+
+      $('#change-name-form').on('submit', function(e) {
+        if ($('#synonym-creation-select').val() !== 'yes') {
+          return;
+        }
+
+        var errors = [];
+        if ($('#change-name-synonymy-cites-id').val() === '') {
+          errors.push('an instance (the name and optional year)');
+        }
+        if ($('#instance_synonym_instance_type_id').val() === '') {
+          errors.push('a type');
+        }
+
+        if (errors.length > 0) {
+          e.preventDefault();
+          e.stopImmediatePropagation();
+          $('#change-name-error-message-container')
+            .html('Please enter ' + errors.join(' and ') +
+                  ' to add this name as a synonym.');
+        } else {
+          $('#change-name-error-message-container').empty();
+        }
+      });
+    </script>
+  </div>
   <div id="change-name-info-message-container" class="message-container"></div>
   <div id="change-name-error-message-container" class="message-container error-container"></div>
   <div id="change-name-refresh-container"></div>
-  <%= f.submit "Change Name",
+  <%= f.submit "Change Name & Create Instance",
                class: "btn btn-primary pull-right no-right-margin",
                title: "Save changed name.",
                style: "padding: 0 10px",

--- a/app/views/instances/tabs/_show_standalone.html.erb
+++ b/app/views/instances/tabs/_show_standalone.html.erb
@@ -6,11 +6,12 @@
 <%= " [#{@instance.name.try('name_status').try('name_without_brackets')}]" if @instance.try('name').try('name_status').try('legitimate?') %>
 
 <% if @instance.draft? && can?(:change_name, @instance) && local_assigns.fetch(:with_name_change, nil) == true %>
-  <%= link_to "change name",
-              "#",
-              onclick: "$('#change-name-form-container').toggle(); return false;",
+  <%= link_to "#",
+              onclick: "$('#change-name-form-container').toggle(); $('#change-name-chevron').toggleClass('fa-chevron-down fa-chevron-up'); return false;",
               title: "Show or hide the change name form",
-              class: "small" %>
+              class: "small" do %>
+    change name <%= editor_icon("chevron-down", "", id: "change-name-chevron", style: "font-size: inherit") %>
+  <% end %>
   <div id="change-name-form-container" style="display: none">
     <%= render 'form_change_name' %>
   </div>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 02-June-2026
+  :jira_id: '5811'
+  :description: |-
+    Add an option to create a synonym for draft instance name change
 - :date: 28-May-2026
   :jira_id: '218'
   :jira_project: FLOR

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.18
+appversion=5.1.3.19

--- a/spec/controllers/instances/change_name_controller_spec.rb
+++ b/spec/controllers/instances/change_name_controller_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Instances::ChangeNameController, type: :controller do
     context "when no name is selected" do
       it "returns an error response without changing the name" do
         expect {
-          patch :update, params: { instance_id: instance.id, instance: { name_id: "" } }, xhr: true
+          patch :update, params: {instance_id: instance.id, instance: {name_id: ""}}, xhr: true
         }.not_to change { instance.reload.name_id }
 
         expect(response).to render_template("instances/change_name_error")
@@ -32,7 +32,7 @@ RSpec.describe Instances::ChangeNameController, type: :controller do
       let(:new_name) { FactoryBot.create(:name, name_type:, name_rank:) }
 
       it "updates the instance name and renders the success template" do
-        patch :update, params: { instance_id: instance.id, instance: { name_id: new_name.id.to_s } }, xhr: true
+        patch :update, params: {instance_id: instance.id, instance: {name_id: new_name.id.to_s}}, xhr: true
 
         expect(instance.reload.name_id).to eq(new_name.id)
         expect(response).to render_template("instances/change_name")
@@ -44,11 +44,57 @@ RSpec.describe Instances::ChangeNameController, type: :controller do
 
       it "returns an error response without changing the name" do
         expect {
-          patch :update, params: { instance_id: instance.id, instance: { name_id: new_name.id.to_s } }, xhr: true
+          patch :update, params: {instance_id: instance.id, instance: {name_id: new_name.id.to_s}}, xhr: true
         }.not_to change { instance.reload.name_id }
 
         expect(response).to render_template("instances/change_name_error")
         expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    context "when adding the name as a synonym" do
+      let(:new_name) { FactoryBot.create(:name, name_type:, name_rank:) }
+      let(:synonym_name) { FactoryBot.create(:name, name_type:, name_rank:) }
+      let(:synonym_instance_type) do
+        FactoryBot.create(:instance_type,
+          relationship: true, primary_instance: false,
+          deprecated: false, unsourced: false, misapplied: false)
+      end
+      let(:cites_instance) do
+        FactoryBot.create(:instance, name: synonym_name, reference: instance.reference)
+      end
+
+      before { allow_any_instance_of(Instance).to receive(:accepted_concept?).and_return(false) }
+
+      it "changes the name and creates the synonym instance" do
+        expect {
+          patch :update, params: {
+            instance_id: instance.id,
+            instance: {
+              name_id: new_name.id.to_s,
+              create_synonym: "yes",
+              cites_id: cites_instance.id.to_s,
+              synonym_instance_type_id: synonym_instance_type.id.to_s
+            }
+          }, xhr: true
+        }.to change { Instance.where(cited_by_id: instance.id).count }.by(1)
+
+        expect(instance.reload.name_id).to eq(new_name.id)
+        expect(response).to render_template("instances/change_name")
+      end
+
+      context "when the instance or type is missing" do
+        it "returns an error without changing the name" do
+          expect {
+            patch :update, params: {
+              instance_id: instance.id,
+              instance: {name_id: new_name.id.to_s, create_synonym: "yes"}
+            }, xhr: true
+          }.not_to change { instance.reload.name_id }
+
+          expect(response).to render_template("instances/change_name_error")
+          expect(response).to have_http_status(:unprocessable_content)
+        end
       end
     end
 
@@ -59,13 +105,13 @@ RSpec.describe Instances::ChangeNameController, type: :controller do
         cites = build(:instance, name: synonym_name, reference: instance.reference)
         cites.save(validate: false)
         syn = build(:instance, cited_by_id: instance.id, cites_id: cites.id,
-                               name: synonym_name, reference: instance.reference)
+          name: synonym_name, reference: instance.reference)
         syn.save(validate: false)
       end
 
       it "returns an error response without changing the name" do
         expect {
-          patch :update, params: { instance_id: instance.id, instance: { name_id: synonym_name.id.to_s } }, xhr: true
+          patch :update, params: {instance_id: instance.id, instance: {name_id: synonym_name.id.to_s}}, xhr: true
         }.not_to change { instance.reload.name_id }
 
         expect(response).to render_template("instances/change_name_error")
@@ -85,13 +131,13 @@ RSpec.describe Instances::ChangeNameController, type: :controller do
       before { matching_name }
 
       it "returns names with the same type and rank" do
-        get :typeahead, params: { instance_id: instance.id, term: "Acacia" }
+        get :typeahead, params: {instance_id: instance.id, term: "Acacia"}
         expect(result_ids).to include(matching_name.id)
       end
 
       it "excludes names with a different rank" do
         other_rank_name = FactoryBot.create(:name, name_type:, name_rank: FactoryBot.create(:name_rank), full_name: "Acacia aneura")
-        get :typeahead, params: { instance_id: instance.id, term: "Acacia" }
+        get :typeahead, params: {instance_id: instance.id, term: "Acacia"}
         expect(result_ids).not_to include(other_rank_name.id)
       end
 
@@ -99,7 +145,7 @@ RSpec.describe Instances::ChangeNameController, type: :controller do
         # current_name has full_name "Sample Full name" — create another same-type name to confirm
         # only the current name is excluded, not all matches
         other_name = FactoryBot.create(:name, name_type:, name_rank:, full_name: "Sample Other name")
-        get :typeahead, params: { instance_id: instance.id, term: "Sample" }
+        get :typeahead, params: {instance_id: instance.id, term: "Sample"}
         expect(result_ids).not_to include(current_name.id)
         expect(result_ids).to include(other_name.id)
       end
@@ -107,7 +153,7 @@ RSpec.describe Instances::ChangeNameController, type: :controller do
 
     context "when the term is blank" do
       it "returns an empty array" do
-        get :typeahead, params: { instance_id: instance.id, term: "" }
+        get :typeahead, params: {instance_id: instance.id, term: ""}
         expect(JSON.parse(response.body)).to eq([])
       end
     end

--- a/spec/services/instances/change_name_service_spec.rb
+++ b/spec/services/instances/change_name_service_spec.rb
@@ -44,7 +44,7 @@ describe Instances::ChangeNameService do
         cites = build(:instance, name: new_name, reference: draft_instance.reference)
         cites.save(validate: false)
         syn = build(:instance, cited_by_id: draft_instance.id, cites_id: cites.id,
-                               name: new_name, reference: draft_instance.reference)
+          name: new_name, reference: draft_instance.reference)
         syn.save(validate: false)
       end
 
@@ -81,6 +81,103 @@ describe Instances::ChangeNameService do
       it "reports an error" do
         service.execute
         expect(service.errors).not_to be_empty
+      end
+    end
+
+    context "when create_synonym is requested" do
+      let(:new_name) { create(:name, name_type:, name_rank:) }
+      let(:synonym_name) { create(:name, name_type:, name_rank:) }
+      let(:synonym_instance_type) do
+        create(:instance_type,
+          relationship: true, primary_instance: false,
+          deprecated: false, unsourced: false, misapplied: false)
+      end
+      let(:cites_instance) do
+        create(:instance, name: synonym_name, reference: draft_instance.reference)
+      end
+
+      subject(:service) do
+        described_class.new(
+          instance: draft_instance,
+          new_name_id: new_name.id,
+          username: username,
+          create_synonym: "yes",
+          cites_id: cites_instance.id,
+          synonym_instance_type_id: synonym_instance_type.id
+        )
+      end
+
+      # accepted_concept? reaches for the live classification tree, which is not
+      # set up in the test database.
+      before { allow_any_instance_of(Instance).to receive(:accepted_concept?).and_return(false) }
+
+      it "changes the instance name" do
+        service.execute
+        expect(draft_instance.reload.name_id).to eq(new_name.id)
+      end
+
+      it "creates one synonym instance cited by this instance" do
+        expect { service.execute }
+          .to change { Instance.where(cited_by_id: draft_instance.id).count }.by(1)
+      end
+
+      it "builds the synonym from the cites instance and chosen type" do
+        service.execute
+        synonym = Instance.find_by(cited_by_id: draft_instance.id, cites_id: cites_instance.id)
+        expect(synonym).to be_present
+        expect(synonym).to have_attributes(
+          name_id: synonym_name.id,
+          instance_type_id: synonym_instance_type.id,
+          reference_id: draft_instance.reference_id
+        )
+      end
+
+      it "succeeds without errors" do
+        service.execute
+        expect(service.errors).to be_empty
+      end
+
+      context "but the user selected no" do
+        subject(:service) do
+          described_class.new(
+            instance: draft_instance,
+            new_name_id: new_name.id,
+            username: username,
+            create_synonym: "no",
+            cites_id: cites_instance.id,
+            synonym_instance_type_id: synonym_instance_type.id
+          )
+        end
+
+        it "changes the name without creating a synonym" do
+          cites_instance # create the standalone instance before measuring
+          expect { service.execute }
+            .not_to change { Instance.where(cited_by_id: draft_instance.id).count }
+          expect(draft_instance.reload.name_id).to eq(new_name.id)
+        end
+      end
+
+      context "when the synonym is invalid" do
+        # The cites instance shares the new name, so the synonym would be a
+        # synonym of itself and fail validation.
+        let(:cites_instance) do
+          create(:instance, name: new_name, reference: draft_instance.reference)
+        end
+
+        it "rolls back the name change" do
+          cites_instance
+          expect { service.execute }.not_to change { draft_instance.reload.name_id }
+        end
+
+        it "does not create a synonym instance" do
+          cites_instance
+          expect { service.execute }.not_to change { Instance.count }
+        end
+
+        it "reports an error" do
+          service.execute
+          expect(service.errors).not_to be_empty
+        end
       end
     end
   end

--- a/test/models/instance/search/created_after/from_dropdown_field/simple_singular_test.rb
+++ b/test/models/instance/search/created_after/from_dropdown_field/simple_singular_test.rb
@@ -21,8 +21,12 @@ load "models/search/users.rb"
 
 # Single instance model test.
 class InstSrchCreAfterFromDropdownSimpleSingularTest < ActiveSupport::TestCase
-  # New search for "42993" on instance up to 100 with field: cr-b
+  # query_string "1" means "changed in the last 1 day", so the test only passes
+  # if the instances look like they changed today. Stamp them with the database's
+  # own clock first to keep the test stable (see Instance.changed_in_the_last_n_days).
   test "instance search on created after from dropdown field simple singular" do
+    Instance.update_all("updated_at = current_timestamp")
+
     search = Search::Base
              .new(ActiveSupport::HashWithIndifferentAccess
                   .new(query_string: "1",


### PR DESCRIPTION
## Summary

- Editors changing the name of a draft instance can now optionally re-add the former name as a synonym in the same step. A Yes/No dropdown on the change-name form reveals fields to pick the cited instance (name + optional year) and the synonym instance type, so the nomenclatural relationship is preserved without a separate trip to the synonymy tab.
- The synonym is created atomically with the name change: if synonym creation fails validation, the whole operation (including the name change) rolls back and the editor sees the error, preventing half-applied changes.
- Both client-side and server-side validation now require the instance and type when "Yes" is selected, so the synonym can't be created with missing fields.
- The change-name form's synonym typeahead was given its own DOM ids and dedicated JS setup so it no longer collides with the existing synonymy tab when both are on the page.
- The change-name toggle now shows an up/down chevron indicating whether the form is expanded.

## Type of change

New feature (full stack: ERB view + JS typeahead + controller + service), with RSpec coverage for the controller and service.

## Technical details

- Synonym creation lives in `Instances::ChangeNameService` and mirrors the canonical creation path used by `InstancesController#create_cites_and_cited_by` → `#build_them`: `name_id` and `reference_id` are derived from the cited/cited-by instances rather than trusting incoming params (`name_id = cites.name_id`, `reference_id = cited_by.reference_id`), and `draft`/override flags fall through to model defaults.
- The name change and synonym creation run inside a single `ActiveRecord::Base.transaction`; the service adds to `errors` and raises `ActiveRecord::Rollback` so a bad synonym never leaves a renamed-but-orphaned instance.
- The synonym typeahead previously reused the generic `instance-instance-for-name-showing-reference-typeahead` / `instance_cites_id` ids and `setUpSynonymyInstance()` shared with `_tab_synonymy_for_profile_v2`, causing field interference. It now uses `change-name-synonymy-*` ids, a hidden `change-name-current-name-id` field for rank restriction, and a dedicated `setUpChangeNameSynonymyInstance()` Bloodhound.

## Test plan
- [x] On a draft standalone instance, open the "change name" toggle and confirm the chevron flips between down (collapsed) and up (expanded).
- [x] Pick a valid new name (same type and rank), select "Yes", choose a cited instance via the typeahead and a synonym type, submit — confirm the name changes and the former name appears as a synonym of the instance.
- [x] Select "Yes" but leave the instance and/or type blank — confirm submission is blocked client-side with the inline error, and (bypassing JS) that the server also rejects it.
- [x] Select "No" and submit — confirm the name changes and no synonym is created.
- [x] Force a synonym validation failure (e.g. a cites instance whose name equals the new name) — confirm the name change is rolled back and an error is shown.
- [x] Open an instance where both the change-name form and the synonymy tab are present — confirm the two typeaheads operate independently.

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
