### PR TITLE
FLOR-240 Fix missing profile tab by gating manage_profile on product reference

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -87,7 +87,12 @@ class Ability
   def draft_profile_editor(user)
     can :manage, :profile_v2
     can :manage_profile, Instance do |instance|
-      instance.draft? && instance.profile_items.includes([:product]).any? { |item| item.product && item.product == user.product_from_context }
+      next false unless instance.draft?
+
+      context_product = user.product_from_context
+      next false unless context_product
+
+      context_product.has_the_same_reference?(instance)
     end
     can [:create, :read], Author
     can :update, Author do |author|

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,5 +1,10 @@
+- :date: 04-June-2026
+  :jira_id: '240'
+  :jira_project: FLOR
+  :description: |-
+    Fixup the profile tab not showing up when instance has no profile items but is part of a concept with profile items
 - :date: 03-June-2026
-  :jira_id: 
+  :jira_id:
   :description: |-
     Regression tests: Added some Claude suggested - no user testing required.
 - :date: 02-June-2026

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.20
+appversion=5.1.3.21

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -112,25 +112,26 @@ RSpec.describe Ability, type: :model do
       end
     end
 
-    it 'can manage draft instances with matching product profile items' do
+    it 'can manage draft instances when the reference matches the product' do
       instance = create(:instance, draft: true)
-      profile_item = double('profile_item', product: product)
-      profile_items_relation = double('profile_items_relation')
-      allow(profile_items_relation).to receive(:includes).with([:product]).and_return([profile_item])
-      allow(instance).to receive(:profile_items).and_return(profile_items_relation)
+      allow(product).to receive(:has_the_same_reference?).with(instance).and_return(true)
       expect(subject.can?(:manage_profile, instance)).to eq true
     end
 
-    it 'cannot manage draft instances without matching product profile items' do
+    it 'cannot manage draft instances when the reference does not match the product' do
       instance = create(:instance, draft: true)
-      profile_items_relation = double('profile_items_relation')
-      allow(profile_items_relation).to receive(:includes).with([:product]).and_return([])
-      allow(instance).to receive(:profile_items).and_return(profile_items_relation)
+      allow(product).to receive(:has_the_same_reference?).with(instance).and_return(false)
       expect(subject.can?(:manage_profile, instance)).to eq false
     end
 
     it 'cannot manage non-draft instances' do
       instance = create(:instance, draft: false)
+      expect(subject.can?(:manage_profile, instance)).to eq false
+    end
+
+    it 'cannot manage draft instances when there is no product in context' do
+      allow(session_user).to receive(:product_from_context).and_return(nil)
+      instance = create(:instance, draft: true)
       expect(subject.can?(:manage_profile, instance)).to eq false
     end
 


### PR DESCRIPTION
## Summary

- Fix the missing profile tab for draft instances: the `draft_profile_editor` role could only `manage_profile` on an instance that *already* had profile items belonging to its context product, so a freshly created draft with no profile items yet was denied and the profile tab never rendered.
- Gate the `manage_profile` ability on whether the instance's reference matches the context product (`has_the_same_reference?`) instead of on the presence of existing profile items, so editors can open the profile tab and start adding content.
- Bail out early when there is no product in context, avoiding a nil-product edge case.

## Type of change

Bug fix (authorisation / access control).

## Technical details

The previous check required `instance.profile_items` to contain an item whose product equalled the user's context product. This is a chicken-and-egg condition — you needed profile items to gain the permission that lets you create profile items. The new logic reuses `Product#has_the_same_reference?`, the same predicate already used by `create_adnot` and the profile/classification tab view helpers, so the gating is now consistent across the ability and the views.

## Test plan

- [x] As a `draft-profile-editor` whose context product matches a draft instance's reference, open the instance — the Profile tab is visible and editable.
- [x] On a brand-new draft instance with no profile items yet (matching reference), confirm the Profile tab now appears (previously hidden).
- [x] With a context product whose reference does NOT match the instance, confirm the Profile tab is hidden / `manage_profile` denied.
- [x] With no product selected in context, confirm `manage_profile` is denied and nothing errors.
- [x] Confirm a name-index product context is still excluded from this role (unchanged behaviour).
