### PR TITLE
NSL-5776 Wire up the bootstrap helpers in the menu and layout 

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -7,7 +7,14 @@ import "@hotwired/turbo-rails"
 import "controllers";
 import "jQuery"; // select2 needs this case-sensitive version of jQuery - "jquery" gives error
 import "select2"; // this import first
-import "dropdown";
+// Bootstrap dropdowns/collapse: BS5 bundle (native, data-bs-* driven, toggles
+// .show) when the feature flag is on; otherwise the legacy BS3 jQuery plugin
+// (toggles .open). jQuery itself stays loaded for select2/typeahead either way.
+if (window.useLatestBootstrap) {
+  import("bootstrap");
+} else {
+  import("dropdown");
+}
 //import "fresh";
 //// start of fresh replacements
 import "debug";

--- a/app/javascript/menu_ops.js
+++ b/app/javascript/menu_ops.js
@@ -20,16 +20,17 @@
     return event.stopPropagation();
   };
 
+  // BS3 marks an open dropdown with .open; BS5 uses .show. Match both.
   showSearchResultDetailsIfMenusClosed = function() {
     debug('showSearchResultDetailsIfMenusClosed');
-    if ($('li.dropdown.open').length === 0) {
+    if ($('li.dropdown.open, li.dropdown.show').length === 0) {
       return $('#search-result-details').show();
     }
   };
 
   hideSearchResultDetailsIfMenusOpen = function() {
     debug('hideSearchResultDetailsIfMenusOpen');
-    if ($('li.dropdown.open').length > 0) {
+    if ($('li.dropdown.open, li.dropdown.show').length > 0) {
       return $('#search-result-details').hide();
     }
   };

--- a/app/views/layouts/_admin_menu.html.erb
+++ b/app/views/layouts/_admin_menu.html.erb
@@ -5,7 +5,7 @@
      class="dropdown-toggle"
      tabindex="5"
      <%= 'active' if params[:controller].match(/admin/) %>
-     data-toggle="dropdown">Admin<span class="caret"></span></a>
+     <%= bs_toggle(:dropdown) %>>Admin<span class="caret"></span></a>
   <ul id="admin-dropdown-menu" class="dropdown-menu" role="menu"> 
     <li class=""
         role="presentation">

--- a/app/views/layouts/_batch_menu.html.erb
+++ b/app/views/layouts/_batch_menu.html.erb
@@ -4,7 +4,7 @@
      class="dropdown-toggle"
      tabindex="5"
      title="Batch loader menu"
-     data-toggle="dropdown"><%= default_batch||'Batch' %><span class="caret"></span></a>
+     <%= bs_toggle(:dropdown) %>><%= default_batch||'Batch' %><span class="caret"></span></a>
   <ul id="batch-dropdown-menu" class="dropdown-menu width-15em" role="menu"> 
       <% Loader::Batch.all.order(:name).each do |batch| %>
         <li role="presentation">

--- a/app/views/layouts/_help_menu.html.erb
+++ b/app/views/layouts/_help_menu.html.erb
@@ -4,7 +4,7 @@
        id="help-dropdown-menu-link"
        class="dropdown-toggle"
        tabindex="3"
-       data-toggle="dropdown">Help<span class="caret"></span>
+       <%= bs_toggle(:dropdown) %>>Help<span class="caret"></span>
     </a>
     <ul id="create-dropdown-menu" class="dropdown-menu" role="menu">
       <li role="presentation">

--- a/app/views/layouts/_menus.html.erb
+++ b/app/views/layouts/_menus.html.erb
@@ -1,7 +1,7 @@
 <%# navigation styled for Bootstrap 3.0 %>
   <div class="container-fluid">
     <div id="navbar-header" class="navbar-header"> 
-      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+      <button type="button" class="<%= navbar_toggle_class %>" <%= bs_toggle(:collapse, target: ".navbar-collapse") %>>
         <span class="sr-only">Toggle navigation</span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>

--- a/app/views/layouts/_new_menu.html.erb
+++ b/app/views/layouts/_new_menu.html.erb
@@ -3,7 +3,7 @@
        id="new-dropdown-menu-link"
        class="dropdown-toggle"
        tabindex="2"
-       data-toggle="dropdown">New<span class="caret"></span>
+       <%= bs_toggle(:dropdown) %>>New<span class="caret"></span>
     </a>
     <ul id="create-dropdown-menu" class="dropdown-menu" role="menu">
         <li class="dropdown-submenu">

--- a/app/views/layouts/_new_multi_product_menu.html.erb
+++ b/app/views/layouts/_new_multi_product_menu.html.erb
@@ -3,7 +3,7 @@
     id="new-dropdown-menu-link"
     class="dropdown-toggle"
     tabindex="2"
-    data-toggle="dropdown"
+    <%= bs_toggle(:dropdown) %>
   >
     New<span class="caret"></span>
   </a>

--- a/app/views/layouts/_product_context_menu.html.erb
+++ b/app/views/layouts/_product_context_menu.html.erb
@@ -4,7 +4,7 @@
     class="dropdown-toggle"
     title="Select Working Context"
     id="context-dropdown-menu-link"
-    data-toggle="dropdown">
+    <%= bs_toggle(:dropdown) %>>
     <i class="fa fa-eye"></i>
     <%= current_context_name %>
     <span class="caret"></span>

--- a/app/views/layouts/_taxonomy_menu.html.erb
+++ b/app/views/layouts/_taxonomy_menu.html.erb
@@ -9,7 +9,7 @@
        tabindex="4"
        class="dropdown-toggle <%= 'active' if params[:controller].match(/session/) %>"
        title='<%= @working_draft ? selected_draft_title + " is the selected draft" : "Draft taxonomy menu. Choose a draft taxonomy to work on here." %>'
-       data-toggle="dropdown">
+       <%= bs_toggle(:dropdown) %>>
       <i class="fa fa-sitemap"></i>
       <% if @working_draft %>
         <%= "#{selected_draft_title[0,14]}#{ '...' if selected_draft_title.length > 15 } #{editor_icon 'check'}".html_safe %>

--- a/app/views/layouts/_user_menu.html.erb
+++ b/app/views/layouts/_user_menu.html.erb
@@ -6,7 +6,7 @@
      tabindex="4"
      class="dropdown-toggle <%= 'active' if params[:controller].match(/session/) %>"
      title="Select this to see your account options."
-     data-toggle="dropdown">
+     <%= bs_toggle(:dropdown) %>>
     <%= editor_icon('user') %>&nbsp;<%= @current_user.full_name %> <span class="caret"></span>
   </a>
   <ul id="user-dropdown-menu" class="dropdown-menu" role="menu">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,6 +11,7 @@
       window.relative_url_root = "<%= Rails.application.config.action_controller.relative_url_root %>";
       window.enablePromptUnsavedChanges = <%= Rails.configuration.try('unsaved_form_prompt_enabled') || false %>;
       window.enableSiteWidePromptUnsavedChanges = <%= Rails.configuration.try('site_wide_form_prompt_enabled') || false %>;
+      window.useLatestBootstrap = <%= bootstrap5? %>;
     </script>
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/showdown/1.9.1/showdown.js"
@@ -30,8 +31,13 @@
       <%= favicon_link_tag 'favicon-fallback.png?v=1', :rel => 'shortcut icon' %>
     <% end %>
 
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
-          integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <% if bootstrap5? %>
+      <%= stylesheet_link_tag "bootstrap.min", media: "all" %>
+      <%= stylesheet_link_tag "bootstrap5-compat", media: "all" %>
+    <% else %>
+      <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+            integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+    <% end %>
 
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
 

--- a/app/views/layouts/review/_menus.html.erb
+++ b/app/views/layouts/review/_menus.html.erb
@@ -1,7 +1,7 @@
 <%# navigation styled for Bootstrap 3.0 %>
   <div class="container-fluid">
     <div id="navbar-header" class="navbar-header"> 
-      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+      <button type="button" class="<%= navbar_toggle_class %>" <%= bs_toggle(:collapse, target: ".navbar-collapse") %>>
         <span class="sr-only">Toggle navigation</span>
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>

--- a/app/views/search/_search_target.html.erb
+++ b/app/views/search/_search_target.html.erb
@@ -4,7 +4,7 @@
                 class="btn btn-default dropdown-toggle" 
                 tabindex="7"
                 title="Target of the search"
-                data-toggle="dropdown" 
+                <%= bs_toggle(:dropdown) %>
                 aria-haspopup="true" 
                 aria-expanded="false">
           <span id="search-target-button-text">

--- a/app/views/search/review/_search_target.html.erb
+++ b/app/views/search/review/_search_target.html.erb
@@ -4,7 +4,7 @@
                 class="btn btn-default dropdown-toggle" 
                 tabindex="7"
                 title="Target of the search"
-                data-toggle="dropdown" 
+                <%= bs_toggle(:dropdown) %>
                 aria-haspopup="true" 
                 aria-expanded="false">
           <span id="search-target-button-text">

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 05-June-2026
+  :jira_id: '5776'
+  :description: |-
+    Wire up the bootstrap helpers in the html menu and layout
 - :date: 04-June-2026
   :jira_id: '5776'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.22
+appversion=5.1.3.23


### PR DESCRIPTION
# Summary
- Switch every navbar dropdown and collapse toggle to render through BootstrapUpgradeHelper (bs_toggle, navbar_toggle_class) so the same templates emit BS5 data-bs-* attributes and navbar-toggler when the flag is on, and legacy BS3 data-*/navbar-toggle markup when it's off.
- Load the correct front-end assets per flag in the layout: BS5 vendored CSS + native JS bundle when bootstrap5?, otherwise the existing BS3 CDN stylesheet and dropdown jQuery plugin. The flag is also exposed to JS as window.useLatestBootstrap to drive the dynamic import("bootstrap") vs import("dropdown").
- Keep search-result show/hide logic working under both versions by matching both the BS3 .open and BS5 .show dropdown states.

## Type of change
  Front-end wiring — the menu/layout integration step of the flag-gated Bootstrap 3 → 5 upgrade (NSL-5776). No user-visible change with the flag off; relies on the helper and config flag added in the prior commit. Please note that currently the UIs are broken when the flag is ON (on bootstrap 5), they will be addressed in the upcoming PRs.

### Technical details
- The flag is read in two synchronized places: server-side bootstrap5? for ERB markup, and window.useLatestBootstrap (set in application.html.erb) for the client-side conditional import. jQuery stays loaded regardless, since select2/typeahead depend on it even when the native BS5 bundle is active.
- Toggle attributes are no longer hard-coded in templates — centralizing them in the helper keeps a single template tree serving both versions and makes the eventual BS3 removal a delete-the-helper-and-its-callers operation.

## Test plan
- [x] Flag off (default): confirm all top-nav dropdowns (Admin, Batch, Help, New, Taxonomy, User, Product context) and the search-target dropdown open/close, and the navbar collapses on narrow viewports — no regression to current BS3 behaviour.