### PR TITLE
NSL-5776 Bootstrap 5 compatibility shim for legacy BS3 views (phase 2)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,143 @@
+#!/bin/bash
+#
+# pre-commit: warn about Bootstrap 3/4 classes that were removed or renamed in
+# Bootstrap 5.
+#
+# Why: this app is mid-migration to Bootstrap 5 (see vendor/assets/stylesheets/
+# bootstrap5-compat.css, which shims the legacy classes the existing views still
+# use). The shim keeps old markup rendering, but we don't want NEW code to keep
+# introducing BS3 classes — that just grows the pile we eventually have to undo.
+#
+# What it does: scans only the ADDED lines in the staged diff (not whole files),
+# so editing a legacy file doesn't nag you about classes that were already there
+# — it only flags BS3 classes you're introducing in this commit.
+#
+# It is a WARNING, not a gate: the commit still proceeds. Set BS5_STRICT=1 to
+# make it block instead (exit non-zero), e.g. in CI:  BS5_STRICT=1 git commit ...
+#
+# Bypass entirely with the standard:  git commit --no-verify
+#
+# Installed via core.hooksPath=.githooks (see bin/setup).
+# Implemented in Perl for portability (macOS ships BSD awk, which mishandles
+# multi-line program data; Perl is reliably present and already used by the
+# repo's other hooks).
+
+# Only scan front-end-ish files. Keeps the scan fast and avoids matching the
+# class tokens inside unrelated Ruby/SQL/etc.
+globs=('*.erb' '*.html' '*.html.erb' '*.haml' '*.js' '*.jsx' '*.css' '*.scss' '*.rb')
+
+# Nothing staged in those file types -> nothing to do.
+if ! git diff --cached --name-only --diff-filter=ACM -- "${globs[@]}" | grep -q .; then
+  exit 0
+fi
+
+# The Perl scanner reads `git diff --cached -U0`, which emits per changed file:
+# a `+++ b/<path>` header, `@@ ... +start,count @@` hunk headers, and `+`/`-`
+# lines (no context lines at -U0). It tracks the current file and new-file line
+# number so it can report file:line for each offending added line.
+#
+# Rules live in the @rules table below as [regex, suggestion]. Each regex is
+# matched with class-boundary lookarounds so e.g. `pull-right` won't fire inside
+# `xpull-right`. We deliberately skip ultra-generic words (hidden, caret,
+# divider, media, label, well, panel) that collide with plain English/HTML.
+output=$(git diff --cached -U0 --diff-filter=ACM -- "${globs[@]}" | perl -e '
+# Each rule is [display-name, match-regex, suggestion]. Keeping the human label
+# separate from the regex means findings read "pull-right" rather than the raw
+# compiled pattern.
+my @rules = (
+  [ "pull-left",        qr/pull-left/,        "float-start" ],
+  [ "pull-right",       qr/pull-right/,       "float-end" ],
+  [ "img-responsive",   qr/img-responsive/,   "img-fluid" ],
+  [ "img-circle",       qr/img-circle/,       "rounded-circle" ],
+  [ "img-rounded",      qr/img-rounded/,      "rounded" ],
+  [ "center-block",     qr/center-block/,     "mx-auto (with d-block)" ],
+  [ "btn-default",      qr/btn-default/,      "btn-secondary / btn-light" ],
+  [ "btn-xs",           qr/btn-xs/,           "btn-sm" ],
+  [ "col-xs-*",         qr/col-xs-[0-9]+/,    "col-[n] (the default, no-prefix tier)" ],
+  [ "col-*-offset-*",   qr/col-(?:sm|md|lg|xl)-offset-[0-9]+/, "offset-(sm|md|lg|xl)-[n]" ],
+  [ "form-group",       qr/form-group/,       "removed — use spacing utilities (e.g. mb-3)" ],
+  [ "navbar-inverse",   qr/navbar-inverse/,   "navbar-dark" ],
+  [ "navbar-fixed-top", qr/navbar-fixed-top/, "fixed-top" ],
+  [ "navbar-fixed-bottom", qr/navbar-fixed-bottom/, "fixed-bottom" ],
+  [ "navbar-static-top",   qr/navbar-static-top/,   "sticky-top" ],
+  [ "navbar-toggle",    qr/navbar-toggle/,    "navbar-toggler" ],
+  [ "navbar-right",     qr/navbar-right/,     "ms-auto" ],
+  [ "navbar-left",      qr/navbar-left/,      "me-auto" ],
+  [ "has-error",        qr/has-error/,        "is-invalid" ],
+  [ "has-success",      qr/has-success/,      "is-valid" ],
+  [ "has-warning",      qr/has-warning/,      "removed — use is-invalid / is-valid" ],
+  [ "help-block",       qr/help-block/,       "form-text" ],
+  [ "control-label",    qr/control-label/,    "col-form-label" ],
+  [ "input-group-btn",  qr/input-group-btn/,  "removed — put the .btn directly in .input-group" ],
+  [ "input-group-addon",qr/input-group-addon/,"input-group-text" ],
+  [ "glyphicon",        qr/glyphicon/,        "removed — use bootstrap-icons or an <svg>/font-awesome icon" ],
+  [ "hidden-{xs,sm,md,lg}",  qr/hidden-(?:xs|sm|md|lg)/,  "d-none / d-(sm|md|lg)-none responsive display utilities" ],
+  [ "visible-{xs,sm,md,lg}", qr/visible-(?:xs|sm|md|lg)/, "d-* responsive display utilities" ],
+  [ "dl-horizontal",    qr/dl-horizontal/,    "removed — use .row on the <dl> with grid columns" ],
+  [ "page-header",      qr/page-header/,      "removed — use a heading with border-bottom + pb-2" ],
+  [ "sr-only",          qr/sr-only/,          "visually-hidden" ],
+  [ "panel-default",    qr/panel-default/,    "card" ],
+  [ "panel-heading",    qr/panel-heading/,    "card-header" ],
+  [ "panel-body",       qr/panel-body/,       "card-body" ],
+  [ "panel-title",      qr/panel-title/,      "card-title" ],
+  [ "panel-footer",     qr/panel-footer/,     "card-footer" ],
+  [ "well-{lg,sm}",     qr/well-(?:lg|sm)/,   "removed — use .card or .border with padding" ],
+  [ "thumbnail",        qr/thumbnail/,        "removed — use .img-thumbnail (image) or .card (block)" ],
+  [ "label-{default,primary,...}", qr/label-(?:default|primary|success|info|warning|danger)/, "badge text-bg-*" ],
+);
+
+my ($file, $newline, $hits) = ("", 0, 0);
+while (my $line = <STDIN>) {
+  if ($line =~ m{^\+\+\+ b/(.*)}) { $file = $1; next; }
+  if ($line =~ m{^\@\@ .*\+(\d+)})  { $newline = $1; next; }   # new-file start line
+  if ($line =~ m{^\+}) {                                        # an added line
+    my $text = substr($line, 1);
+    for my $r (@rules) {
+      my ($name, $pat, $sug) = @$r;
+      # class-boundary: token not flanked by [A-Za-z0-9_-]
+      if ($text =~ /(?<![A-Za-z0-9_-])$pat(?![A-Za-z0-9_-])/) {
+        printf "  %s:%d\n      .%s  ->  %s\n", $file, $newline, $name, $sug;
+        $hits++;
+      }
+    }
+    $newline++;
+    next;
+  }
+  # `-` (removed) lines do not advance the new-file counter; no context at -U0.
+}
+exit($hits > 0 ? 2 : 0);
+')
+status=$?
+
+if [ "$status" -eq 2 ]; then
+  # Colours (fall back to plain if not a tty / no tput).
+  if [ -t 2 ] && command -v tput >/dev/null 2>&1 && [ "$(tput colors 2>/dev/null || echo 0)" -ge 8 ]; then
+    Y=$(tput setaf 3); R=$(tput setaf 1); B=$(tput bold); N=$(tput sgr0)
+  else
+    Y=""; R=""; B=""; N=""
+  fi
+
+  {
+    echo ""
+    echo "${Y}${B}⚠  Bootstrap 5 compatibility warning${N}"
+    echo "${Y}   The lines you're adding use Bootstrap 3/4 classes that BS5 removed or renamed:${N}"
+    echo ""
+    echo "$output"
+    echo ""
+    echo "   These currently only work because of the BS3 shim"
+    echo "   (vendor/assets/stylesheets/bootstrap5-compat.css). Prefer the BS5 class so we"
+    echo "   don't grow the migration backlog."
+    if [ -n "$BS5_STRICT" ]; then
+      echo ""
+      echo "${R}${B}   BS5_STRICT is set — blocking this commit.${N} Fix the classes above, or unset BS5_STRICT."
+      echo "$N"
+      exit 1
+    fi
+    echo ""
+    echo "   This is a warning only — your commit will proceed."
+    echo "   Bypass this hook with: ${B}git commit --no-verify${N}"
+    echo "$N"
+  } >&2
+fi
+
+exit 0

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
-# pre-commit: warn about Bootstrap 3/4 classes that were removed or renamed in
-# Bootstrap 5.
+# pre-commit: block commits that introduce Bootstrap 3/4 classes that were
+# removed or renamed in Bootstrap 5.
 #
 # Why: this app is mid-migration to Bootstrap 5 (see vendor/assets/stylesheets/
 # bootstrap5-compat.css, which shims the legacy classes the existing views still
@@ -12,8 +12,8 @@
 # so editing a legacy file doesn't nag you about classes that were already there
 # — it only flags BS3 classes you're introducing in this commit.
 #
-# It is a WARNING, not a gate: the commit still proceeds. Set BS5_STRICT=1 to
-# make it block instead (exit non-zero), e.g. in CI:  BS5_STRICT=1 git commit ...
+# It is a GATE: if any introduced line uses a flagged BS3/4 class, the commit is
+# blocked (exit non-zero). Fix the classes to proceed.
 #
 # Bypass entirely with the standard:  git commit --no-verify
 #
@@ -119,7 +119,7 @@ if [ "$status" -eq 2 ]; then
 
   {
     echo ""
-    echo "${Y}${B}⚠  Bootstrap 5 compatibility warning${N}"
+    echo "${R}${B}✖  Bootstrap 5 compatibility check failed${N}"
     echo "${Y}   The lines you're adding use Bootstrap 3/4 classes that BS5 removed or renamed:${N}"
     echo ""
     echo "$output"
@@ -127,17 +127,12 @@ if [ "$status" -eq 2 ]; then
     echo "   These currently only work because of the BS3 shim"
     echo "   (vendor/assets/stylesheets/bootstrap5-compat.css). Prefer the BS5 class so we"
     echo "   don't grow the migration backlog."
-    if [ -n "$BS5_STRICT" ]; then
-      echo ""
-      echo "${R}${B}   BS5_STRICT is set — blocking this commit.${N} Fix the classes above, or unset BS5_STRICT."
-      echo "$N"
-      exit 1
-    fi
     echo ""
-    echo "   This is a warning only — your commit will proceed."
-    echo "   Bypass this hook with: ${B}git commit --no-verify${N}"
+    echo "${R}${B}   Blocking this commit.${N} Fix the classes above to proceed, or bypass with:"
+    echo "   ${B}git commit --no-verify${N}"
     echo "$N"
   } >&2
+  exit 1
 fi
 
 exit 0

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# pre-push: confirm before pushing to the main/master branch.
+# (Ported from the previous untracked .git/hooks/pre-push so it survives the
+# switch to core.hooksPath=.githooks and is shared with the team.)
+
+# Get the remote name and URL
+remote="$1"
+url="$2"
+
+# Read push references
+while read local_ref local_sha remote_ref remote_sha; do
+    echo "Processing push to $remote_ref..."
+    # Check if pushing to the main branch on the upstream remote
+    if [ "$remote_ref" = "refs/heads/main" ] || [ "$remote_ref" = "refs/heads/master" ]; then
+        echo "You are about to push to the main branch of $remote_ref."
+
+        # Prompt for confirmation
+        # Force user input even in a non-interactive shell
+        echo -n "Are you sure? (yes/no): " > /dev/tty
+        read choice < /dev/tty
+        case "$choice" in
+            yes|YES )
+                echo "Pushing to $remote_ref..."
+                ;;
+            * )
+                echo "Push to $remote_ref aborted."
+                exit 1
+                ;;
+        esac
+    fi
+done
+
+exit 0

--- a/app/assets/stylesheets/components/jira.css
+++ b/app/assets/stylesheets/components/jira.css
@@ -1,3 +1,7 @@
+span.jira {
+  float: right;
+}
+
 span.jira.in-test {
   background: darkred;
 }

--- a/app/javascript/menu_ops.js
+++ b/app/javascript/menu_ops.js
@@ -1,5 +1,5 @@
 (function() {
-  var dropdownSubmenuClick, hideDetails, hideSearchResultDetailsIfMenusOpen, showSearchResultDetailsIfMenusClosed;
+  var dropdownSubmenuClick, hideDetails;
 
   $(document).on("turbo:load", function() {
   // Do NOT close the menu when submenu is clicked.
@@ -12,27 +12,16 @@
       return hideDetails(event, $(this));
     });
 
+    // NOTE: under BS5 we no longer hide #search-result-details when a navbar
+    // dropdown opens. The panel now stays put and the dropdown overlays it
+    // (matching BS3) — see the #top-navbar z-index lift in bootstrap5-compat.css.
+
   });
 
 
   dropdownSubmenuClick = function(event, $element) {
     event.preventDefault();
     return event.stopPropagation();
-  };
-
-  // BS3 marks an open dropdown with .open; BS5 uses .show. Match both.
-  showSearchResultDetailsIfMenusClosed = function() {
-    debug('showSearchResultDetailsIfMenusClosed');
-    if ($('li.dropdown.open, li.dropdown.show').length === 0) {
-      return $('#search-result-details').show();
-    }
-  };
-
-  hideSearchResultDetailsIfMenusOpen = function() {
-    debug('hideSearchResultDetailsIfMenusOpen');
-    if ($('li.dropdown.open, li.dropdown.show').length > 0) {
-      return $('#search-result-details').hide();
-    }
   };
 
   hideDetails = function(event, $this) {

--- a/app/views/search/_search_form.html.erb
+++ b/app/views/search/_search_form.html.erb
@@ -7,10 +7,10 @@
     <div id="search-field-and-buttons-container" class="flex-container input-group">
 
       <%= render partial: 'search/search_target' %>
- 
-      <input id="query-string-field" 
-             name="query_string" 
-             type="search" 
+
+      <input id="query-string-field"
+             name="query_string"
+             type="search"
              class="xform-control"
              aria-label="search field"
              tabindex = "8"

--- a/bin/setup
+++ b/bin/setup
@@ -13,7 +13,12 @@ FileUtils.chdir APP_ROOT do
   # This script is idempotent, so that you can run it at any time and get an expectable outcome.
   # Add necessary setup steps to this file.
 
-  puts "== Installing dependencies =="
+  puts "== Installing git hooks =="
+  # Point git at the tracked .githooks dir (BS5 class warning + push guard).
+  # Idempotent: re-running just re-sets the same config value.
+  system! "git config core.hooksPath .githooks"
+
+  puts "\n== Installing dependencies =="
   system("bundle check") || system!("bundle install")
 
   # puts "\n== Copying sample files =="

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 10-June-2026
+  :jira_id: '5776'
+  :description: |-
+    Fixup the issue where the bootstrap upgrade was causing some styling issues in the html menu and layout
 - :date: 05-June-2026
   :jira_id: '5776'
   :description: |-

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,3 +10,7 @@ Rails.application.config.assets.version = "1.0"
 # Rails.configuration.use_latest_bootstrap_version is true).
 Rails.application.config.assets.paths << Rails.root.join("vendor", "assets", "stylesheets")
 Rails.application.config.assets.precompile += %w[bootstrap.min.css]
+
+# Precompile the BS3->BS5 compatibility shim (loaded only when the
+# use_latest_bootstrap_version flag is on). The vendor stylesheet path it
+Rails.application.config.assets.precompile += %w[bootstrap5-compat.css]

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.23
+appversion=5.1.3.24

--- a/vendor/assets/stylesheets/bootstrap5-compat.css
+++ b/vendor/assets/stylesheets/bootstrap5-compat.css
@@ -413,7 +413,14 @@ ul.navbar-nav li a.dropdown-toggle {
   border-top-left-radius: 4px;
   border-top-right-radius: 4px;
 }
-.nav-tabs > li > a:hover {
+.nav-tabs > li > a:hover,
+.nav-tabs > li > a:focus {
+  /* Restore BS3's base `.nav > li > a:hover/:focus { background-color:#eee }`.
+     BS5 dropped it (it styles .nav-link, not .nav>li>a, and applies no hover
+     fill), so without this an inactive tab loses its grey hover. The active tab
+     stays white via `.nav-tabs > li.active > a:hover` below (higher specificity,
+     loads after). */
+  background-color: #eee;
   border-color: #e9ecef #e9ecef #dee2e6;
 }
 .nav-tabs > li.active > a,
@@ -452,4 +459,9 @@ input#query-submit {
 
 div#search-field-and-buttons-container div#search-target-btn.input-group-btn {
   width: 12%;
+}
+
+/* Search result tabs */
+#top-navbar ul#search-results-tabset {
+  top: 116px;
 }

--- a/vendor/assets/stylesheets/bootstrap5-compat.css
+++ b/vendor/assets/stylesheets/bootstrap5-compat.css
@@ -1,0 +1,267 @@
+/* ==========================================================================
+   Bootstrap 3 -> 5 compatibility shim.
+
+   Loaded ONLY when Rails.configuration.use_latest_bootstrap_version is true
+   (see app/views/layouts/application.html.erb). Bridges the shallow set of
+   Bootstrap 3 classes this app still uses onto Bootstrap 5.3.x so the existing
+   views render correctly without a full markup rewrite.
+
+   Load order in <head>: bootstrap.min.css -> THIS FILE -> application.css.
+   The app's own heavy navbar/dropdown styling lives in application.css and
+   loads in both flag states, so this shim only supplies the structural pieces
+   Bootstrap 5 removed or renamed.
+
+   When the BS3 fallback is eventually retired, fold any still-needed rules into
+   the main stylesheets and delete this file.
+   ========================================================================== */
+
+/* --- Typography: preserve the app's compact 14px density (BS3 default) -------
+   BS5 defaults to 16px/1.5 which would reflow every tuned form. */
+body {
+  font-size: 14px;
+}
+
+/* --- .hidden : CRITICAL. BS3 shipped this; BS5 removed it. The layout and
+   tabs.js use .hidden to show/hide the main-body containers and tab panels.
+   Without this, every hidden container renders at once. ----------------------- */
+.hidden {
+  display: none !important;
+}
+
+/* --- Grid: BS5 dropped the xs tier (xs == the default, no-prefix tier).
+   The app uses col-xs-* (mostly col-xs-12). Re-create the widths. ------------- */
+.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6,
+.col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12 {
+  position: relative;
+  width: 100%;
+  padding-right: calc(var(--bs-gutter-x, 1.5rem) * 0.5);
+  padding-left: calc(var(--bs-gutter-x, 1.5rem) * 0.5);
+}
+.col-xs-1  { flex: 0 0 8.333333%;  max-width: 8.333333%;  }
+.col-xs-2  { flex: 0 0 16.666667%; max-width: 16.666667%; }
+.col-xs-3  { flex: 0 0 25%;        max-width: 25%;        }
+.col-xs-4  { flex: 0 0 33.333333%; max-width: 33.333333%; }
+.col-xs-5  { flex: 0 0 41.666667%; max-width: 41.666667%; }
+.col-xs-6  { flex: 0 0 50%;        max-width: 50%;        }
+.col-xs-7  { flex: 0 0 58.333333%; max-width: 58.333333%; }
+.col-xs-8  { flex: 0 0 66.666667%; max-width: 66.666667%; }
+.col-xs-9  { flex: 0 0 75%;        max-width: 75%;        }
+.col-xs-10 { flex: 0 0 83.333333%; max-width: 83.333333%; }
+.col-xs-11 { flex: 0 0 91.666667%; max-width: 91.666667%; }
+.col-xs-12 { flex: 0 0 100%;       max-width: 100%;       }
+
+/* --- Forms: .form-group was removed in BS5 (it only added a bottom margin). -- */
+.form-group {
+  margin-bottom: 15px;
+}
+
+/* Sizing lock so the app's existing `.form-control { height: 26px }` override
+   (in components/new-for-rails-6.css) doesn't clip text under BS5's larger
+   default padding/line-height. Keeps typeahead + select2 inputs aligned. */
+input.form-control,
+select.form-control {
+  padding: 3px 8px;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+/* --- Buttons: .btn-default was removed in BS5. Re-create the BS3 light look. - */
+.btn-default {
+  color: #333;
+  background-color: #fff;
+  border-color: #ccc;
+}
+.btn-default:hover,
+.btn-default:focus,
+.btn-default:active,
+.btn-default.active {
+  color: #333;
+  background-color: #e6e6e6;
+  border-color: #adadad;
+}
+
+/* --- Float helpers: BS5 renamed pull-left/right to float-start/end. --------- */
+.pull-left  { float: left  !important; }
+.pull-right { float: right !important; }
+
+/* --- Misc removed helpers --------------------------------------------------- */
+.center-block { display: block; margin-right: auto; margin-left: auto; }
+.text-muted   { color: #6c757d !important; }
+
+/* --- .sr-only : renamed to .visually-hidden in BS5. ------------------------- */
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+/* --- Dropdown caret : BS3 used an explicit <span class="caret">; BS5 renders
+   the caret as ::after on .dropdown-toggle. Reproduce the span triangle and
+   suppress BS5's auto-caret so we don't get two. --------------------------- */
+.caret {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  margin-left: 2px;
+  vertical-align: middle;
+  border-top: 4px dashed;
+  border-top: 4px solid \9;
+  border-right: 4px solid transparent;
+  border-left: 4px solid transparent;
+}
+.dropdown-toggle::after {
+  display: none;
+}
+
+/* --- Dropdown menu items: BS5 only styles .dropdown-item; the app emits
+   ul.dropdown-menu > li > a. Style that BS3 structure. (The app's own
+   dropdown CSS in application.css layers on top of this.) ------------------- */
+.dropdown-menu > li > a {
+  display: block;
+  width: 100%;
+  padding: 4px 16px;
+  clear: both;
+  font-weight: 400;
+  color: #212529;
+  text-align: inherit;
+  white-space: nowrap;
+  background-color: transparent;
+  border: 0;
+  text-decoration: none;
+}
+.dropdown-menu > li > a:hover,
+.dropdown-menu > li > a:focus {
+  color: #1e2125;
+  background-color: #e9ecef;
+}
+/* BS3 .divider inside a dropdown -> BS5 .dropdown-divider */
+.dropdown-menu .divider {
+  height: 0;
+  margin: 8px 0;
+  overflow: hidden;
+  border-top: 1px solid #e9ecef;
+}
+
+/* --- Input group: BS5 removed .input-group-btn (the search-target dropdown
+   uses it). Make it lay out as a flex item again. -------------------------- */
+.input-group-btn {
+  display: flex;
+  position: relative;
+}
+
+/* --- Navbar: BS5 rewrote the navbar. The app's detailed navbar styling lives
+   in application.css; here we only restore structural BS3 pieces BS5 dropped
+   or changed so that layout/colours/positioning hold up. ------------------- */
+
+/* CRITICAL: BS5 makes .navbar AND .navbar > .container-fluid flex rows. The
+   app's #top-navbar wraps a .container-fluid containing several stacked .row
+   blocks (menu row, searchbar row, summary row); BS5's flex collapses them
+   into one squished horizontal row. BS3's .navbar was block-level, so restore
+   that for the app's BS3-era stacked navbar layout. */
+.navbar {
+  display: block;
+  padding: 0;
+}
+.navbar > .container,
+.navbar > .container-fluid {
+  display: block;
+}
+
+/* CRITICAL: the menu markup is `<div class="collapse navbar-collapse">` with no
+   .navbar-expand-* class, so BS5's `.collapse:not(.show){display:none}` would
+   hide the whole menu. BS3 force-showed .navbar-collapse on desktop via a media
+   query; replicate that. (This is a desktop-only app — it shows a "window too
+   small" message on narrow viewports — so always-expanded matches behaviour.) */
+.navbar-collapse {
+  display: block !important;
+}
+
+.navbar-inverse {
+  background-color: #222;
+  border-color: #080808;
+}
+.navbar-inverse .navbar-nav > li > a,
+.navbar-inverse .navbar-brand,
+.navbar-inverse .dropdown-toggle {
+  color: #9d9d9d;
+}
+.navbar-inverse .navbar-nav > li > a:hover,
+.navbar-inverse .navbar-nav > li > a:focus,
+.navbar-inverse .navbar-brand:hover {
+  color: #fff;
+}
+.navbar-fixed-top {
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 1030;
+}
+/* BS5 .navbar-nav is a vertical flex column by default; the app's menu is
+   horizontal. */
+.navbar-nav {
+  flex-direction: row;
+  flex-wrap: wrap;
+  padding-left: 0;
+  margin-bottom: 0;
+  list-style: none;
+}
+.navbar-nav > li {
+  list-style: none;
+}
+/* Legacy navbar toggle button + its icon bars (BS3 markup kept via helper for
+   the BS3 path; under BS5 the helper emits .navbar-toggler, but the icon-bar
+   spans remain in the markup). */
+.navbar-toggle {
+  position: relative;
+  float: right;
+  padding: 9px 10px;
+  margin-top: 8px;
+  margin-right: 15px;
+  margin-bottom: 8px;
+  background-color: transparent;
+  background-image: none;
+  border: 1px solid transparent;
+  border-radius: 4px;
+}
+.navbar-toggle .icon-bar,
+.navbar-toggler .icon-bar {
+  display: block;
+  width: 22px;
+  height: 2px;
+  margin: 4px 0;
+  background-color: #888;
+  border-radius: 1px;
+}
+
+/* --- Tabs: tabs.js keeps .active on the <li> (BS3 style); BS5 expects it on
+   the .nav-link anchor. Style the BS3 structure. --------------------------- */
+.nav-tabs > li {
+  margin-bottom: -1px;
+}
+.nav-tabs > li > a {
+  display: block;
+  padding: 8px 16px;
+  color: #606060;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+.nav-tabs > li > a:hover {
+  border-color: #e9ecef #e9ecef #dee2e6;
+}
+.nav-tabs > li.active > a,
+.nav-tabs > li.active > a:hover,
+.nav-tabs > li.active > a:focus {
+  color: #495057;
+  cursor: default;
+  background-color: #fff;
+  border-color: #dee2e6 #dee2e6 #fff;
+}

--- a/vendor/assets/stylesheets/bootstrap5-compat.css
+++ b/vendor/assets/stylesheets/bootstrap5-compat.css
@@ -21,6 +21,20 @@ body {
   font-size: 14px;
 }
 
+/* Headings: BS5's reboot zeroes heading top margins (margin-top:0); BS3 gave
+   h1–h3 a 20px top margin and h4–h6 a 10px top margin. The app was built around
+   that spacing, so without it headings sit flush against whatever precedes them
+   — e.g. the detail panel's first heading touching the panel's top edge.
+   Restore the BS3 margins. */
+h1, h2, h3 {
+  margin-top: 20px;
+  margin-bottom: 10px;
+}
+h4, h5, h6 {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
 /* --- .hidden : CRITICAL. BS3 shipped this; BS5 removed it. The layout and
    tabs.js use .hidden to show/hide the main-body containers and tab panels.
    Without this, every hidden container renders at once. ----------------------- */
@@ -29,26 +43,38 @@ body {
 }
 
 /* --- Grid: BS5 dropped the xs tier (xs == the default, no-prefix tier).
-   The app uses col-xs-* (mostly col-xs-12). Re-create the widths. ------------- */
-.col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6,
-.col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12 {
-  position: relative;
-  width: 100%;
-  padding-right: calc(var(--bs-gutter-x, 1.5rem) * 0.5);
-  padding-left: calc(var(--bs-gutter-x, 1.5rem) * 0.5);
+   The app uses col-xs-* (mostly col-xs-12). Re-create the widths.
+
+   CRITICAL: scope these to the smallest tier ONLY (below the BS5 `sm` 576px
+   breakpoint). BS3's col-xs-* was the BASE tier, declared BEFORE col-sm/md/lg,
+   so the larger tiers overrode it on wider screens. This shim loads AFTER
+   bootstrap.min.css, so an unscoped `.col-xs-12 { ... }` has equal specificity
+   to (and wins over) Bootstrap's `.col-md-9`/`.col-lg-9` — forcing every
+   col-xs-12 element to 100% width and clobbering its col-md/lg width. (That is
+   what made #search-results render full-width and run under the detail panel.)
+   Every col-xs-* in the app's views carries a col-sm/md/lg companion, so below
+   576px these govern and at ≥576px the companions correctly take over. --------- */
+@media (max-width: 575.98px) {
+  .col-xs-1, .col-xs-2, .col-xs-3, .col-xs-4, .col-xs-5, .col-xs-6,
+  .col-xs-7, .col-xs-8, .col-xs-9, .col-xs-10, .col-xs-11, .col-xs-12 {
+    position: relative;
+    width: 100%;
+    padding-right: calc(var(--bs-gutter-x, 1.5rem) * 0.5);
+    padding-left: calc(var(--bs-gutter-x, 1.5rem) * 0.5);
+  }
+  .col-xs-1  { flex: 0 0 8.333333%;  max-width: 8.333333%;  }
+  .col-xs-2  { flex: 0 0 16.666667%; max-width: 16.666667%; }
+  .col-xs-3  { flex: 0 0 25%;        max-width: 25%;        }
+  .col-xs-4  { flex: 0 0 33.333333%; max-width: 33.333333%; }
+  .col-xs-5  { flex: 0 0 41.666667%; max-width: 41.666667%; }
+  .col-xs-6  { flex: 0 0 50%;        max-width: 50%;        }
+  .col-xs-7  { flex: 0 0 58.333333%; max-width: 58.333333%; }
+  .col-xs-8  { flex: 0 0 66.666667%; max-width: 66.666667%; }
+  .col-xs-9  { flex: 0 0 75%;        max-width: 75%;        }
+  .col-xs-10 { flex: 0 0 83.333333%; max-width: 83.333333%; }
+  .col-xs-11 { flex: 0 0 91.666667%; max-width: 91.666667%; }
+  .col-xs-12 { flex: 0 0 100%;       max-width: 100%;       }
 }
-.col-xs-1  { flex: 0 0 8.333333%;  max-width: 8.333333%;  }
-.col-xs-2  { flex: 0 0 16.666667%; max-width: 16.666667%; }
-.col-xs-3  { flex: 0 0 25%;        max-width: 25%;        }
-.col-xs-4  { flex: 0 0 33.333333%; max-width: 33.333333%; }
-.col-xs-5  { flex: 0 0 41.666667%; max-width: 41.666667%; }
-.col-xs-6  { flex: 0 0 50%;        max-width: 50%;        }
-.col-xs-7  { flex: 0 0 58.333333%; max-width: 58.333333%; }
-.col-xs-8  { flex: 0 0 66.666667%; max-width: 66.666667%; }
-.col-xs-9  { flex: 0 0 75%;        max-width: 75%;        }
-.col-xs-10 { flex: 0 0 83.333333%; max-width: 83.333333%; }
-.col-xs-11 { flex: 0 0 91.666667%; max-width: 91.666667%; }
-.col-xs-12 { flex: 0 0 100%;       max-width: 100%;       }
 
 /* --- Forms: .form-group was removed in BS5 (it only added a bottom margin). -- */
 .form-group {
@@ -78,6 +104,41 @@ select.form-control {
   color: #333;
   background-color: #e6e6e6;
   border-color: #adadad;
+}
+
+/* CRITICAL: contextual button colours when the variant class is used WITHOUT
+   the base `.btn` class. Many of the app's `f.submit` buttons emit just
+   `class: 'btn-primary'` (no `btn`) — e.g. the "Create Instance" button. In BS3
+   each `.btn-*` rule set `color`/`background`/`border` directly, so the variant
+   alone painted itself (white text on a coloured fill). BS5 moved those onto the
+   base `.btn` via CSS custom properties: `.btn-primary` now only sets
+   `--bs-btn-color:#fff` etc., and the actual `color: var(--bs-btn-color)` lives
+   on `.btn`. With no `.btn` on the element the variables are never consumed, so
+   the text falls back to the default dark colour while the fill (overridden to
+   #606060 in new-for-rails-6.css for primary) still paints — giving a grey
+   button with dark text. Re-declare the colours directly so the variant works
+   standalone, exactly as BS3 did and as `.btn-default` above already does.
+   new-for-rails-6.css loads AFTER this shim, so its #606060 primary fill still
+   wins; only the white text is restored here. */
+.btn-primary {
+  color: #fff;
+  background-color: #0d6efd;
+  border-color: #0d6efd;
+}
+.btn-success {
+  color: #fff;
+  background-color: #198754;
+  border-color: #198754;
+}
+.btn-danger {
+  color: #fff;
+  background-color: #dc3545;
+  border-color: #dc3545;
+}
+.btn-warning {
+  color: #000;
+  background-color: #ffc107;
+  border-color: #ffc107;
 }
 
 /* --- Float helpers: BS5 renamed pull-left/right to float-start/end. --------- */
@@ -148,11 +209,56 @@ select.form-control {
   border-top: 1px solid #e9ecef;
 }
 
-/* --- Input group: BS5 removed .input-group-btn (the search-target dropdown
-   uses it). Make it lay out as a flex item again. -------------------------- */
-.input-group-btn {
+/* --- Input group: CRITICAL. The app's two search bars (search/_search_form +
+   search/review/_search_form — the ONLY `.input-group` users in the app) put a
+   `.input-group-btn` "Names" dropdown, the `#query-string-field` input, and the
+   `#query-submit` button in a row. BS5 rebuilt `.input-group` as a flex row that
+   (a) only *sizes* children carrying `.form-control` — and this app's field is
+   deliberately `xform-control`, so it's skipped — and (b) joins items with
+   `margin-left:-1px` plus a `z-index:2` on `.btn`, which tucked the buttons over
+   the field's corners. Result: overlapping, misaligned items.
+
+   A BS3-style `display:table` model fixes the overlap but `display:table-cell`
+   is honoured inconsistently on replaced FORM controls — WebKit/Blink stretch
+   the text <input> to the row height (tall white box) while treating the
+   <input type=submit> differently, so they end up different heights. So drive it
+   with flex instead, which aligns inputs and buttons uniformly:
+     - align-items:center      -> reliable vertical centring across element types
+     - the field flex-grows    -> fills the row like BS3's field did
+     - buttons hug their width  -> no growth/shrink
+     - zero the negative-margin joins -> nothing overlaps
+   Scoped to `.input-group` is safe: the only instances are these two search
+   bars. -------------------------------------------------------------------- */
+.input-group {
   display: flex;
-  position: relative;
+  flex-wrap: nowrap;
+  align-items: center;
+  width: 100%;
+}
+/* Kill BS5's -1px border-collapse join, plus the BS3 nudge margins new-for-
+   rails-6 put on the field/submit (-4px left on the submit, 3px top on the
+   field, 3px bottom on the submit). The left margins caused overlap; the
+   vertical ones would push items off-centre now that align-items:center applies.
+   The submit/field need ID specificity to beat `input#query-...` rules. */
+.input-group > * {
+  margin-left: 0;
+  margin-top: 0;
+  margin-bottom: 0;
+}
+#query-submit {
+  margin: 0;
+}
+.input-group > .input-group-btn {
+  position: relative;   /* anchors the absolutely-positioned dropdown menu */
+  flex: 0 0 auto;
+}
+.input-group > #query-string-field {
+  min-width: 0;         /* allow it to shrink instead of forcing overflow */
+  margin-top: 0;        /* beats input#query-string-field{margin-top:3px} */
+  margin-bottom: 0;
+}
+.input-group > .btn {
+  flex: 0 0 auto;
 }
 
 /* --- Navbar: BS5 rewrote the navbar. The app's detailed navbar styling lives
@@ -182,6 +288,50 @@ select.form-control {
   display: block !important;
 }
 
+/* CRITICAL: BS3 laid the navbar out with floats on desktop (≥768px) so the
+   brand and the menu sit on ONE line; the toggle button was hidden. BS5 drives
+   the navbar with flex, dropped those floats, and shows .navbar-toggler by
+   default. The result is the brand dropping onto its own line with a stray
+   hamburger above it. This is a desktop-only app (it shows a "window too small"
+   message on narrow viewports), so apply BS3's ≥768px float model
+   unconditionally rather than behind a media query. */
+.navbar-header {
+  float: left;
+}
+.navbar-brand {
+  float: left;
+}
+/* Hide the collapse toggle outright — the navbar never collapses here. */
+.navbar-toggle,
+.navbar-toggler {
+  display: none;
+}
+
+/* CRITICAL: BS5 defaults `.navbar-nav .dropdown-menu` to position:static and
+   only restores position:absolute under a `.navbar-expand-*` class — which this
+   app's navbar does not use. A static dropdown sits in normal flow, ignores
+   z-index, and so renders BEHIND the searchbar row stacked below it. Restore
+   absolute positioning exactly as `.navbar-expand` would, so the menu floats
+   over the content below. */
+.navbar-nav .dropdown-menu {
+  position: absolute;
+}
+
+/* NOTE on navbar vs the floating #search-result-details panel: both sit at
+   z-index:80 (old-application.css / layout-using-dashboard.css) and the panel
+   comes later in the DOM, so the panel paints OVER the navbar. This is what we
+   want: the fixed right panel overflows its #main-content div upward over the
+   navbar bar and must stay on top so its top edge isn't clipped. We deliberately
+   do NOT lift #top-navbar above the panel.
+
+   KNOWN TRADE-OFF: an open navbar dropdown is confined to the navbar's z-80
+   fixed stacking context, so where a (wide) dropdown reaches into the panel's
+   area it is painted under the panel. There is no CSS-only way to have the panel
+   above the navbar bar AND the dropdown above the panel, because the dropdown is
+   a descendant of the fixed navbar; the only real fix is rendering dropdowns to
+   <body> (Popper container). Accepted as-is. menu_ops.js no longer hides the
+   panel when a menu opens. */
+
 .navbar-inverse {
   background-color: #222;
   border-color: #080808;
@@ -204,10 +354,14 @@ select.form-control {
   z-index: 1030;
 }
 /* BS5 .navbar-nav is a vertical flex column by default; the app's menu is
-   horizontal. */
+   horizontal. Keep the flex row for the items, but float the whole nav left so
+   it sits beside the floated .navbar-header (BS3 desktop model) instead of
+   dropping below it. */
 .navbar-nav {
+  display: flex;
   flex-direction: row;
   flex-wrap: wrap;
+  float: left;
   padding-left: 0;
   margin-bottom: 0;
   list-style: none;
@@ -218,6 +372,11 @@ select.form-control {
 /* Legacy navbar toggle button + its icon bars (BS3 markup kept via helper for
    the BS3 path; under BS5 the helper emits .navbar-toggler, but the icon-bar
    spans remain in the markup). */
+
+ul.navbar-nav li a.dropdown-toggle {
+  display: block;
+}
+
 .navbar-toggle {
   position: relative;
   float: right;
@@ -264,4 +423,33 @@ select.form-control {
   cursor: default;
   background-color: #fff;
   border-color: #dee2e6 #dee2e6 #fff;
+}
+
+/* Table styles */
+.table > thead > tr > th,
+.table > tbody > tr > th,
+.table > tfoot > tr > th,
+.table > thead > tr > td,
+.table > tbody > tr > td,
+.table > tfoot > tr > td {
+  border-top: 1px solid #ddd;
+  border-bottom: 1px solid #ddd;
+}
+
+/* Search form */
+input#query-submit {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  margin-bottom: 3px;
+  margin-left: -4px;
+  height: 25px;
+  border-bottom: 1px solid lightgray;
+  border-top: 1px solid lightgray;
+  border-left: 1px solid lightgray;
+  margin-top: 3px;
+  padding-top: 0;
+}
+
+div#search-field-and-buttons-container div#search-target-btn.input-group-btn {
+  width: 12%;
 }

--- a/vendor/assets/stylesheets/bootstrap5-compat.css
+++ b/vendor/assets/stylesheets/bootstrap5-compat.css
@@ -141,6 +141,29 @@ select.form-control {
   border-color: #ffc107;
 }
 
+/* --- Button focus ring: BS5 replaced BS3's `outline` focus indicator with a
+   .25rem `box-shadow` ring (applied on :focus-visible). The app flattens button
+   focus via `input.btn:focus / a.btn:focus { outline: none }` (controls.css) —
+   but `outline:none` does NOT remove a box-shadow, so under BS5 the ring leaks
+   through (e.g. when keyboard-focusing a button) where BS3 showed none. Suppress
+   the box-shadow so buttons keep the app's flat BS3 look. --------------------- */
+.btn:focus,
+.btn:focus-visible,
+.btn:active:focus,
+.btn.active:focus {
+  box-shadow: none;
+}
+
+/* Extend the app's grey primary-active fill (new-for-rails-6.css only covers
+   `input.btn.btn-primary:active`) to non-input primary buttons. Otherwise a
+   primary <button>/<a> on :active shows BS5's computed blue --bs-btn-active-bg
+   instead of the app's #474747. */
+.btn-primary:active,
+.btn-primary.active {
+  background: #474747;
+  border-color: #474747;
+}
+
 /* --- Float helpers: BS5 renamed pull-left/right to float-start/end. --------- */
 .pull-left  { float: left  !important; }
 .pull-right { float: right !important; }
@@ -464,4 +487,8 @@ div#search-field-and-buttons-container div#search-target-btn.input-group-btn {
 /* Search result tabs */
 #top-navbar ul#search-results-tabset {
   top: 116px;
+}
+
+#search-target-button-text {
+  color: #333;
 }


### PR DESCRIPTION
## Summary

- Introduce a feature-flagged **Bootstrap 3 → 5 compatibility shim** (`bootstrap5-compat.css`) so the app's existing BS3-class markup renders correctly under Bootstrap 5.3.x without a full view rewrite. It is only loaded/precompiled when `use_latest_bootstrap_version` is on, so the BS3 path is untouched.
- Fix the visual regressions that surfaced once the BS5 flag was wired up: submit buttons (e.g. **"Create Instance"**) rendering with dark instead of white text, the **search bar** fields overlapping and vertically misaligned, and headings sitting flush against the detail-panel edge.
- Stop hiding the right-hand **detail panel** when a navbar dropdown opens. The panel now stays put and overlays the navbar (matching BS3) instead of vanishing on every menu.

## Type of change

Part of a larger, feature-flagged Bootstrap 3.3.7 → 5.3.8 upgrade (**phase 2**, following #766 and #767). Almost entirely CSS/JS compatibility work gated behind `use_latest_bootstrap_version`; there is **no change when the flag is off**.

## Technical details

A few non-obvious root causes the shim addresses:

- **Button text colour** — BS5 defines variant colours only as CSS custom properties consumed by the base `.btn` (`color: var(--bs-btn-color)`). Many of the app's `f.submit` buttons emit just `class: 'btn-primary'` with no base `.btn`, so the variable is never consumed and the text falls back to dark while the app's `#606060` fill still paints. The shim re-declares the variant colours directly, as BS3 did.
- **Search bar layout** — BS5 dropped the table-based `.input-group` and only sizes children carrying `.form-control`; the query field is intentionally `xform-control`, so it was excluded from BS5's flex sizing, leaving the items overlapping and misaligned. The shim rebuilds the input-group as a flex row (`align-items:center`, field flex-grows, negative-margin joins zeroed).
- **Detail panel vs navbar stacking** — both sit at `z-index:80`; the panel is later in the DOM so it stays on top, which is what we want (its top isn't clipped). The known trade-off: an open dropdown is trapped in the `position:fixed` navbar's stacking context, so a wide dropdown overlaps *behind* the panel. There is no CSS-only way to have the panel above the navbar **and** dropdowns above the panel — that would require rendering dropdowns to `<body>` (Popper container) — so this is accepted as-is.

## Test plan

With `use_latest_bootstrap_version` **on**:

- [x] Open a Name → Instances tab and confirm the **"Create Instance"** / submit buttons show white text on the coloured fill.
- [x] Search bar: the **"Names"** target dropdown, the query field, and the **"Search …"** button sit on one line, vertically centred, with no overlap.
- [x] Open each top-nav menu (New, Help, Admin, user, FOA) with a record selected — the **right detail panel stays visible** (no longer disappears) and the dropdown renders over the page; the panel's top stays above the navbar bar.
- [x] Spot-check headings, tabs, `.hidden` containers, and `col-xs-*` widths render as before.

With the flag **off**:

- [x] Confirm the shim is not loaded and the BS3 UI is unchanged.
