### PR TITLE
NSL-5776 - Fix BS5 button states for signin and search forms

### DIFF
--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 12-June-2026
+  :jira_id: '5776'
+  :description: |-
+    CSS fixes for the signin and search forms buttons for bs5
+- :date: 12-June-2026
   :jira_id: '3085'
   :description: |-
     Instance search: Fix offset: directive

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.29
+appversion=5.1.3.30

--- a/vendor/assets/stylesheets/bootstrap5-compat.css
+++ b/vendor/assets/stylesheets/bootstrap5-compat.css
@@ -150,7 +150,8 @@ select.form-control {
   /* The disabled state has its own variables: Rails' `data-disable-with` adds
      `disabled` to the submit button while the form is in flight, and BS5 paints
      `.btn:disabled` from these — blue (#0d6efd) by default — so a submitting
-     Sign in button flashed blue. Keep it grey (dimmed via --bs-btn-disabled-opacity). */
+     Sign in button flashed blue. Keep it the app's solid grey (the global
+     --bs-btn-disabled-opacity:1 below keeps it opaque rather than washed-out). */
   --bs-btn-disabled-bg: #606060;
   --bs-btn-disabled-border-color: #606060;
 }
@@ -201,6 +202,28 @@ select.form-control {
 .btn-primary.active {
   background: #474747;
   border-color: #474747;
+}
+
+/* --- Disabled buttons: BS5 dims `.btn:disabled` with
+   `opacity: var(--bs-btn-disabled-opacity)` (.65). Over the app's coloured
+   chrome (e.g. the purple search navbar) that 65% opacity lets the background
+   bleed through, so a disabled button reads as washed-out / transparent rather
+   than a solid greyed-out control — BS3 kept the fill opaque. Restore opacity
+   to 1 so disabled buttons stay solid. The app's own deliberate dimming
+   (`a.btn-danger[disabled] { opacity: .55 }` in new-for-rails-6.css) uses a
+   more specific attribute selector and loads later, so it still wins where
+   intended. */
+.btn {
+  --bs-btn-disabled-opacity: 1;
+}
+
+/* The search submit (.btn.search-btn) has its own lightgrey fill; when disabled
+   give it a muted, still-opaque grey so it reads as disabled without going
+   see-through. */
+.search-btn:disabled,
+.search-btn.disabled {
+  background: #d6d6d6;
+  color: #888;
 }
 
 /* --- Float helpers: BS5 renamed pull-left/right to float-start/end. --------- */


### PR DESCRIPTION
## Description
- Keep disabled buttons reading as solid greyed-out controls instead of washed-out/see-through. BS5 dims `.btn:disabled` to 65% opacity, which let the app's coloured chrome (e.g. the purple search navbar) bleed through — disabled opacity is now restored to 1 so the fill stays opaque like BS3.
- Give the disabled search submit button (`.search-btn`) a muted, still-opaque grey so it reads as disabled without going transparent.

## Type of change
Bug fix — a visual/CSS regression from the Bootstrap 3 → 5 migration where disabled buttons appeared transparent over coloured backgrounds.

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
