### PR TITLE
NSL-3117: Name validation: Don't allow save of autonym type name with an ineligible rank

### DIFF
--- a/app/models/concerns/name_validatable.rb
+++ b/app/models/concerns/name_validatable.rb
@@ -54,6 +54,7 @@ module NameValidatable
     validates :uri, uniqueness: true, allow_blank: true
     validate :genus_parent_must_match_family_if_both_ranked_family
     validates :name_path, presence: true
+    validate :name_type_autonym_for_restricted_ranks_only
   end
 
   def name_element_is_stripped
@@ -70,6 +71,13 @@ module NameValidatable
     errors.add(:name_type_id,
                "Wrong name type for category! Category: #{category_for_edit} vs
                name type: #{name_type.name}.")
+  end
+
+  def name_type_autonym_for_restricted_ranks_only
+    return unless name_type.autonym?
+    return if name_rank.compatible_with_autonym?
+
+    errors.add(:name_type_id, "autonym cannot be this rank")
   end
 
   def genus_parent_must_match_family_if_both_ranked_family

--- a/app/models/name_rank.rb
+++ b/app/models/name_rank.rb
@@ -343,6 +343,13 @@ class NameRank < ApplicationRecord
   def can_impact_child_name_construction?
     at_or_below_genus? && not_bracketed?
   end
+
+  # Autonym only exist at the following ranks:
+  #  subdivisions of a genus (i.e. below genus but above species)
+  #  infraspecies (i.e. below species)
+  def compatible_with_autonym?
+    sort_order > NameRank.genus.sort_order && !species? 
+  end
 end
 
 # A stand-in class when there is no parent.

--- a/app/models/name_type.rb
+++ b/app/models/name_type.rb
@@ -201,4 +201,8 @@ class NameType < ApplicationRecord
   def phrase_name?
     name == "phrase name"
   end
+
+  def autonym?
+    name == "autonym"
+  end
 end

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 12-June-2026
+  :jira_id: '3117'
+  :description: |-
+    Name validation: Don't allow save of autonym type name with an ineligible rank
+- :date: 12-June-2026
   :jira_id: '5776'
   :description: |-
     CSS fixes for the signin and search forms buttons for bs5

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.30
+appversion=5.1.3.31

--- a/test/fixtures/names.yml
+++ b/test/fixtures/names.yml
@@ -2259,7 +2259,7 @@ autonym_with_mismatched_name:
   name_element: autonym with mismatched name
   full_name: autonym with mismatched name
   full_name_html: autonym with mismatched name
-  name_rank: species
+  name_rank: subspecies
   name_status: legitimate
   name_type: autonym
   namespace: apni
@@ -2649,5 +2649,38 @@ angophora_fred:
   author: moe
   name_path: 'Plantae/Magnoliophyta/a_family/a_genus/fred'
   uri: agi
+
+# Fixtures for the name_type_autonym_for_restricted_ranks_only validation.
+# A high-ranked parent (regnum) is used so that the parent rank is always
+# higher than the name's rank, no matter what rank we set the name to in the
+# tests. This keeps the autonym-rank validation isolated from the
+# parent-rank-high-enough validation.
+autonym_for_rank_validation:
+  <<: *DEFAULTS
+  name_element: autonymrankvalidation
+  simple_name: autonymrankvalidation
+  full_name: autonymrankvalidation
+  name_rank: subspecies
+  name_status: legitimate
+  name_type: autonym
+  namespace: apni
+  parent: parent_of_autonym_for_rank_validation
+  family: a_family
+  name_path: 'Plantae/test/autonymrankvalidation'
+  uri: autonym_rank_validation_1
+
+parent_of_autonym_for_rank_validation:
+  <<: *DEFAULTS
+  name_element: parentofautonymrankvalidation
+  simple_name: parentofautonymrankvalidation
+  full_name: parentofautonymrankvalidation
+  name_rank: tribus
+  name_status: legitimate
+  name_type: scientific
+  namespace: apni
+  parent_id: nil
+  family: a_family
+  name_path: 'Plantae/test/parentofautonymrankvalidation'
+  uri: autonym_rank_validation_2
 
 

--- a/test/models/name/validations/autonym/name_type_autonym_for_restricted_ranks_only_test.rb
+++ b/test/models/name/validations/autonym/name_type_autonym_for_restricted_ranks_only_test.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Tests for the name_type_autonym_for_restricted_ranks_only validation.
+#
+# An autonym is only valid at:
+#   - subdivisions of a genus (below genus but above species), and
+#   - infraspecific ranks (below species).
+# i.e. ranks whose sort_order is greater than genus and which are not species.
+#
+# Non-autonym name types are unaffected by this validation.
+class NameTypeAutonymForRestrictedRanksOnlyTest < ActiveSupport::TestCase
+  ERROR = "Name type autonym cannot be this rank"
+
+  def autonym
+    names(:autonym_for_rank_validation)
+  end
+
+  test "autonym fixture starts out valid (infraspecific rank)" do
+    name = autonym
+    assert name.valid?,
+           "Autonym at subspecies should be valid. " \
+           "Errs: #{name.errors.full_messages.join('; ')}"
+  end
+
+  test "autonym is valid at an infrageneric rank (subgenus)" do
+    name = autonym
+    name.name_rank = name_ranks(:subgenus)
+    assert name.valid?,
+           "Autonym at subgenus should be valid. " \
+           "Errs: #{name.errors.full_messages.join('; ')}"
+  end
+
+  test "autonym is valid at an infraspecific rank (varietas)" do
+    name = autonym
+    name.name_rank = name_ranks(:varietas)
+    assert name.valid?,
+           "Autonym at varietas should be valid. " \
+           "Errs: #{name.errors.full_messages.join('; ')}"
+  end
+
+  test "autonym is invalid at genus rank" do
+    name = autonym
+    name.name_rank = name_ranks(:genus)
+    assert_not name.valid?, "Autonym at genus should be invalid."
+    assert_includes name.errors.full_messages, ERROR
+  end
+
+  test "autonym is invalid at species rank" do
+    name = autonym
+    name.name_rank = name_ranks(:species)
+    assert_not name.valid?, "Autonym at species should be invalid."
+    assert_includes name.errors.full_messages, ERROR
+  end
+
+  test "autonym is invalid at a rank above genus (familia)" do
+    name = autonym
+    name.name_rank = name_ranks(:familia)
+    assert_not name.valid?, "Autonym above genus should be invalid."
+    assert_includes name.errors.full_messages, ERROR
+  end
+
+  test "non-autonym name type is unaffected at species rank" do
+    name = names(:scientific_name)
+    assert_equal name_ranks(:species), name.name_rank
+    assert name.valid?,
+           "Non-autonym scientific name at species should be valid. " \
+           "Errs: #{name.errors.full_messages.join('; ')}"
+    assert_not_includes name.errors.full_messages, ERROR
+  end
+
+  test "switching a valid name to autonym at species makes it invalid" do
+    name = names(:scientific_name)
+    assert name.valid?, "Scientific name should start out valid."
+    name.name_type = name_types(:autonym)
+    assert_not name.valid?,
+               "Autonym at species rank should not be valid."
+    assert_includes name.errors.full_messages, ERROR
+  end
+end


### PR DESCRIPTION
## Description
See Jira.

## Type of change
- [x] New feature

## How to Test
See Jira

## Tests
- [x] Unit tests - Claude wrote them and I refined slightly
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
