### PR TITLE
NSL-5776 - Fixup bs5 search dropdown overlap

### DIFF
--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 12-June-2026
+  :jira_id: '5776'
+  :description: |-
+    Fixup the dropdown item covering the search field issue in the search form in bs5
+- :date: 12-June-2026
   :jira_id: '3117'
   :description: |-
     Name validation: Don't allow save of autonym type name with an ineligible rank

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.31
+appversion=5.1.3.32

--- a/vendor/assets/stylesheets/bootstrap5-compat.css
+++ b/vendor/assets/stylesheets/bootstrap5-compat.css
@@ -543,7 +543,19 @@ input#query-submit {
 }
 
 div#search-field-and-buttons-container div#search-target-btn.input-group-btn {
-  width: 12%;
+  flex: 0 0 auto;
+  width: auto;
+}
+div#search-field-and-buttons-container #search-target-button {
+  display: inline-flex;
+  align-items: center;
+  max-width: 16em;
+}
+div#search-field-and-buttons-container #search-target-button-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* Search result tabs */


### PR DESCRIPTION
## Description
- Fix the search-target dropdown overlapping the query input under Bootstrap 5 (use_latest_bootstrap_version): the dropdown now sizes to its label and truncates with an ellipsis instead of overflowing onto the search field when a long target like "References, names, full synonymy" is selected.

## Type of change
- CSS/UI bug fix scoped to the bs5 compatibility path

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
