### PR TITLE
Table borders for bs5

### DIFF
--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 15-June-2026
+  :jira_id: '5776'
+  :description: |-
+    Fixup the table border in bs5 in the help page
 - :date: 12-June-2026
   :jira_id: '5776'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.3.32
+appversion=5.1.3.33

--- a/vendor/assets/stylesheets/bootstrap5-compat.css
+++ b/vendor/assets/stylesheets/bootstrap5-compat.css
@@ -528,6 +528,14 @@ ul.navbar-nav li a.dropdown-toggle {
   border-bottom: 1px solid #ddd;
 }
 
+table[border] {
+  border-collapse: collapse;
+}
+table[border] th,
+table[border] td {
+  border: 1px solid #999;
+}
+
 /* Search form */
 input#query-submit {
   border-top-left-radius: 0;


### PR DESCRIPTION
## Description
- Bring back the grid lines on the help "Query Help" rules/matrix tables (e.g. the name Category × Type matrix), which had lost every border under the Bootstrap 5 theme and rendered as borderless walls of text.

## Type of change
CSS bug fix, scoped to the Bootstrap 5 compatibility shim (only active when use_latest_bootstrap_version is on). Part of the ongoing BS3 → BS5 migration. No markup, model, or schema changes.

## Technical details
Bootstrap 5's Reboot declares thead, tbody, tfoot, tr, td, th { border-style: solid; border-width: 0 }. Because that's an author rule, it outranks the browser's border="1" presentational hint (which sits below author styles in the cascade) and zeroes every cell border. The help tables draw their grid purely from that HTML attribute, so under BS5 they came out borderless. The fix re-asserts the borders for any table[border] (border-collapse: collapse + 1px solid #999 on th/td), restoring the BS3 look. Targeting table[border] rather than a single class means every legacy bordered table is covered, and nothing without the attribute (including Bootstrap's own .table) is affected.

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
