### PR TITLE
NSL-3703: Search on Name Status: Allow semi-colons to be used to list name status values in a search

### DIFF
--- a/app/models/search/on_name/predicate.rb
+++ b/app/models/search/on_name/predicate.rb
@@ -22,6 +22,7 @@ class Search::OnName::Predicate
               :trailing_wildcard,
               :leading_wildcard,
               :multiple_values,
+              :allow_split_on_semicolon,
               :predicate,
               :value_frequency,
               :processed_value,
@@ -58,12 +59,10 @@ class Search::OnName::Predicate
     @scope_ = rule[:scope_] || ""
     @trailing_wildcard = rule[:trailing_wildcard] || false
     @leading_wildcard = rule[:leading_wildcard] || false
-    apply_rule_overflow(rule)
-  end
-
-  def apply_rule_overflow(rule)
     @wildcard_embedded_spaces = rule[:wildcard_embedded_spaces] || false
     @multiple_values = rule[:multiple_values] || false
+    @allow_split_on_semicolon = rule[:allow_split_on_semicolon] || false
+    @split_char = work_out_split_char
     @predicate = build_predicate(rule)
     @allow_common_and_cultivar = rule[:allow_common_and_cultivar] || false
     @tokenize = rule[:tokenize] || false
@@ -79,6 +78,13 @@ class Search::OnName::Predicate
                        end
   end
 
+  def work_out_split_char
+    return ',' unless @multiple_values
+    return ',' unless @allow_split_on_semicolon
+
+    @value.match(/;/) ? ';' : ','
+  end
+
   def process_value
     @processed_value = @canon_value
     @processed_value = "%#{@processed_value}" if @leading_wildcard
@@ -90,7 +96,7 @@ class Search::OnName::Predicate
   end
 
   def build_predicate(rule)
-    if @multiple_values && @value.split(",").size > 1
+    if @multiple_values && @value.split(@split_char).size > 1
       rule[:multiple_values_where_clause]
     else
       build_scalar_predicate(rule)
@@ -116,8 +122,8 @@ class Search::OnName::Predicate
   end
 
   def build_canon_value(val)
-    if @multiple_values && @value.split(",").size > 1
-      val.split(",").collect(&:strip)
+    if @multiple_values && @value.split(@split_char).size > 1
+      val.split(@split_char).collect(&:strip)
     else
       val.tr("*", "%")
     end

--- a/app/views/names/advanced_search/_field_help.html.erb
+++ b/app/views/names/advanced_search/_field_help.html.erb
@@ -73,7 +73,11 @@
       {field_name: 'rank:', description: "name rank, allows comma-separated multiple values, single values, and single values with wildcards",partial: "name_ranks/list_for_search_help"},
       {field_name: 'above-rank:', description: "search for names above a specified taxon rank (single value only)"},
       {field_name: 'below-rank:', description: "search for names below a specified taxon rank (single value only)"},
-      {field_name: 'status:', description: "name status, allows comma-separated multiple values, single values, and single values with wildcards",partial: "name_statuses/list_for_search_help"},
+      {field_name: 'status:', description: "name status, allows comma-separated (or semi-colon-separated) multiple values, single values, and single values with wildcards",partial: "name_statuses/list_for_search_help"},
+      {field_name: '', description: "Note for searching name status - some values include a comma, and these will be treated as two values",partial: "name_statuses/list_for_search_help"},
+      {field_name: '', description: "To avoid a search for one name status that includes a comma being treated as two values, replace the comma with an underscore",partial: "name_statuses/list_for_search_help"},
+      {field_name: '', description: "To search for a list of name statuses, including any with a comma, use semi-colons instead of commas to separate the values",partial: "name_statuses/list_for_search_help"},
+      {field_name: '', description: "If your list of name statuses contains any semi-colons, that will be used as the value separator",partial: "name_statuses/list_for_search_help"},
       {field_name: 'type:', description: "name type, allows comma-separated multiple values, single values, and single values with wildcards",partial: "name_types/list_for_search_help"}
       ].each do |val| %>
   <tr>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 24-June-2026
+  :jira_id: '3703'
+  :description: |-
+    Search on Name Status: Allow semi-colons to be used to list name status values in a search
 - :date: 23-June-2026
   :jira_id: '5400'
   :description: |-

--- a/config/name-searches.yml
+++ b/config/name-searches.yml
@@ -196,6 +196,7 @@ from comment where comment.name_id = name.id)"
   :where_clause: name_status_id in       (select id from name_status where lower(name)
     like ?)
   :multiple_values: true
+  :allow_split_on_semicolon: true
   :multiple_values_where_clause: |-
     name_status_id in (select id from name_status where lower(name)
           in (?))

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.3
+appversion=5.1.4.4

--- a/test/models/search/on_name/status/multiple_values_separated_by_semi_colons_test.rb
+++ b/test/models/search/on_name/status/multiple_values_separated_by_semi_colons_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+load "test/models/search/on_name/test_helper.rb"
+
+# Single Search model test for Name target.
+class SearchOnNameStatusMultiSplitOnSemiColonsTest < ActiveSupport::TestCase
+  test "search on name status multiple split on semi colons" do
+    name = names(:isonym_name_one_for_eflora)
+    n2 = names(:nom_cult_name_one_for_eflora)
+    params =  ActiveSupport::HashWithIndifferentAccess
+              .new(query_target: "name",
+                   query_string:
+                   "status: #{name.name_status.name}; #{n2.name_status.name}",
+                   current_user: build_edit_user)
+    search = Search::Base.new(params)
+    confirm_results_class(search.executed_query.results)
+    assert_equal 2,
+                 search.executed_query.results.size,
+                 "Exactly 2 results are expected."
+  end
+end


### PR DESCRIPTION
## Description
See Jira

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How to Test
See Jira

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
