### PR TITLE
Convert rake task to pre-process structure.sql from ed scripts to ruby with Claude's help

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -18,6 +18,7 @@ CREATE SEQUENCE loader.nsl_global_seq
     INCREMENT BY 1
     CACHE 1;
 
+
 CREATE SCHEMA audit;
 
 
@@ -4873,50 +4874,6 @@ CREATE TABLE loader.name_review_vote (
 -- Name: apii_image_profile; Type: FOREIGN TABLE; Schema: public; Owner: -
 --
 
-CREATE FOREIGN TABLE public.apii_image_profile (
-    basis_of_record text,
-    scientific_name character varying(200),
-    family character varying(200),
-    genus character varying(200),
-    species character varying(200),
-    rank_abbrev character varying(10),
-    infraspecies character varying(200),
-    cultivar character varying(200),
-    qualifier character varying(200),
-    catalog_number character varying(50),
-    creator character varying(200),
-    create_date character varying(200),
-    title character varying(500),
-    description character varying(500),
-    caption character varying(2000),
-    priority_rating integer,
-    has_herbarium boolean,
-    has_living boolean,
-    is_flower_image boolean,
-    is_morphology_image boolean,
-    is_illustration boolean,
-    subject_part character varying(500),
-    identifier character varying(200),
-    metadata_date timestamp with time zone,
-    rights character varying(500),
-    rights_owner character varying(500),
-    credit character varying(500),
-    provider_literal character varying(500),
-    access_uri character varying(500),
-    ph_format character varying(200),
-    variant_large character varying(200),
-    variant_medium character varying(200),
-    variant_small character varying(200),
-    update_date timestamp with time zone,
-    photo_no integer,
-    photo_class character varying(10),
-    photo_id integer
-)
-SERVER ibis_pg
-OPTIONS (
-    schema_name 'public',
-    table_name 'apii_image_profile_v'
-);
 
 
 --
@@ -8153,19 +8110,6 @@ CREATE INDEX name_full_name_index ON public.name USING btree (full_name text_pat
 --
 -- Name: name_full_name_trgm_index; Type: INDEX; Schema: public; Owner: -
 --
-
-SET search_path TO nsl, public;
-CREATE EXTENSION IF NOT EXISTS pg_trgm;
-CREATE EXTENSION if not exists unaccent;
-CREATE OR REPLACE FUNCTION public.f_unaccent(text)
- RETURNS text
- LANGUAGE sql
- IMMUTABLE
- SET search_path TO 'public', 'pg_temp'
-AS $function$
-SELECT unaccent('unaccent', $1)
-$function$
-;
 
 CREATE INDEX name_full_name_trgm_index ON public.name USING gin (full_name public.gin_trgm_ops);
 

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -34,55 +34,115 @@ module ActiveRecord
   end
 end
 namespace :db do
+  desc "Clean up the structure.sql file (Ruby version) - run this after you generate structure.sql"
+  task clean_up_structure_sql_ruby: :environment do
+    path = "db/structure.sql"
+    sql  = File.read(path)
+
+    # a — remove CREATE SCHEMA public (already exists in target db)
+    sql.gsub!(/^CREATE SCHEMA public;\n/, "")
+
+    # b — remove get_hstore_tree function
+    sql.gsub!(
+      /^CREATE FUNCTION public\.get_hstore_tree.tve_id text. RETURNS public\.hstore.*?RETURN result_hstore;\n[^\n]*\n[^\n]*\n/m,
+      ""
+    )
+
+    # c — remove taxon_mv materialized view definition
+    sql.gsub!(/^CREATE MATERIALIZED VIEW public\.taxon_mv AS.*?WITH NO DATA;\n/m, "")
+
+    # c1 — remove COMMENT ON MATERIALIZED VIEW public.taxon_mv lines
+    sql.gsub!(/^COMMENT ON MATERIALIZED VIEW public\.taxon_mv[^\n]*\n/, "")
+
+    # c2 — remove COMMENT ON COLUMN public.taxon_mv.* lines
+    sql.gsub!(/^COMMENT ON COLUMN public\.taxon_mv\.[^\n]*\n/, "")
+
+    # d — remove tnu_index_v view (depends on objects not in this schema)
+    sql.gsub!(/^CREATE VIEW public\.tnu_index_v AS.*?ORDER BY[^\n]*\n/m, "")
+
+    # e — remove gettnu function (depends on tnu_index_v)
+    sql.gsub!(
+      /^CREATE FUNCTION public\.gettnu.tnu_name text. RETURNS SETOF public\.tnu_index_v.*?name_published_in_year;\n[^\n]*\n[^\n]*\n/m,
+      ""
+    )
+
+    # f — remove trees_mv materialized view definition
+    sql.gsub!(/^CREATE MATERIALIZED VIEW public\.trees_mv AS.*?WITH NO DATA;\n/m, "")
+
+    # g, h, i, j, k, l — remove views (delete to next blank line)
+    %w[taxon_v nsl_tree_mv cited_usage_v taxon_name_usage_v taxonomic_status_v tree_closure_v].each do |view|
+      sql.gsub!(/^CREATE VIEW public\.#{view} AS.*?\n[ \t]*\n/m, "")
+    end
+
+    # m — remove single-line CREATE statements referencing trees_mv and taxon_mv indexes,
+    #     and the COMMENT ON VIEW public.taxon_view line
+    sql.gsub!(/^CREATE [^\n]*trees_mv[^\n]*;\n/, "")
+    sql.gsub!(/^CREATE [^\n]*taxon_mv[^\n]*;\n/, "")
+    sql.gsub!(/^COMMENT ON VIEW public\.taxon_view IS [^\n]*;\n/, "")
+
+    # n, o, p, q, r, s, t, v, w — remove more views (delete to next blank line)
+    %w[bdr_alt_labels_v bdr_concept_v bdr_top_concept_v bdr_unplaced_v
+       current_scheme_v dist_granular_booleans_v dwc_taxon_v nsl_taxon_cv nsl_tree_closure_cv].each do |view|
+      sql.gsub!(/^CREATE VIEW public\.#{view} AS.*?\n[ \t]*\n/m, "")
+    end
+
+    # u — remove COMMENT ON VIEW public.dwc_taxon_v
+    sql.gsub!(/^COMMENT ON VIEW public\.dwc_taxon_v IS [^\n]*;\n/, "")
+
+    # x — remove taxon_mv_compare table
+    sql.gsub!(/^CREATE TABLE public\.taxon_mv_compare.*?\n[ \t]*\n/m, "")
+
+    # y — remove taxon_view
+    sql.gsub!(/^CREATE VIEW public\.taxon_view AS.*?\n[ \t]*\n/m, "")
+
+    # z — remove name_mv materialized view
+    sql.gsub!(/^CREATE MATERIALIZED VIEW public\.name_mv AS.*?\n[ \t]*\n/m, "")
+
+    # z1 — remove taxon_name_v view
+    sql.gsub!(/^CREATE VIEW public\.taxon_name_v AS.*?\n[ \t]*\n/m, "")
+
+    # z2 — remove all remaining COMMENT ON lines
+    sql.gsub!(/^COMMENT ON [^\n]*;\n/, "")
+
+    # z3, z4, z5 — remove more views
+    sql.gsub!(/^CREATE VIEW public\.dwc_name_v AS.*?\n[ \t]*\n/m, "")
+    sql.gsub!(/^CREATE VIEW public\.name_view AS.*?\n[ \t]*\n/m, "")
+    sql.gsub!(/^CREATE VIEW public\.wfo_export AS.*?\n[ \t]*\n/m, "")
+
+    # remove foreign tables (reference servers that don't exist in test/dev environments)
+    sql.gsub!(/^CREATE FOREIGN TABLE public\.apii_image_profile.*?;\n/m, "")
+
+    # z6 — omitted: pg_dump now exports extensions and f_unaccent directly,
+    #      and structure_load creates extensions before every schema load.
+
+    # z7 — remove index/constraint statements on name_mv and audit triggers
+    sql.gsub!(/^CREATE [^\n]* ON public\.name_mv[^\n]*;\n/, "")
+    sql.gsub!(/^CREATE TRIGGER audit[^\n]*;\n/, "")
+
+    # z8 — add CREATE SCHEMA audit after CREATE SCHEMA loader
+    sql.gsub!(/^(CREATE SCHEMA loader;)$/, "\\1\nCREATE SCHEMA audit;")
+
+    # z9 — remove sequence range constraints
+    sql.gsub!(/^[^\n]*START WITH 50000001[^\n]*\n/, "")
+    sql.gsub!(/^[^\n]*MINVALUE 50000001[^\n]*\n/, "")
+    sql.gsub!(/^[^\n]*MAXVALUE 60000000[^\n]*\n/, "")
+
+    # z9a — add loader sequence definition after CREATE SCHEMA loader
+    loader_sequence = "CREATE SEQUENCE loader.nsl_global_seq\n    INCREMENT BY 1\n    CACHE 1;\n\n"
+    sql.gsub!(/^(CREATE SCHEMA loader;)/, "\\1\n#{loader_sequence}")
+
+    # z9b — remove nsl_name_rank materialized view
+    sql.gsub!(/^CREATE MATERIALIZED VIEW public\.nsl_name_rank AS.*?\n[ \t]*\n/m, "")
+
+    File.write(path, sql)
+    puts "db/structure.sql cleaned up"
+  end
+
   desc "Create required PostgreSQL extensions in the current database"
   task create_extensions: :environment do
     ActiveRecord::Base.connection.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
     ActiveRecord::Base.connection.execute("CREATE EXTENSION IF NOT EXISTS unaccent")
   end
-
-  desc "Clean up the structure.sql file - run this after you generate structure.sql"
-  task clean_up_structure_sql: :environment do
-    sh "ed db/structure.sql <lib/scripts/structure/a.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/b.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/c.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/c1.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/c2.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/d.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/e.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/f.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/g.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/h.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/i.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/j.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/k.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/l.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/m.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/n.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/o.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/p.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/q.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/r.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/s.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/t.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/u.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/v.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/w.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/x.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/y.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/z.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/z1.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/z2.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/z3.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/z4.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/z5.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/z6.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/z7.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/z8.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/z9.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/z9a.ed"
-    sh "ed db/structure.sql <lib/scripts/structure/z9b.ed"
-  end
-
 end
 
 


### PR DESCRIPTION
## Description
Working on the problem of updating our structure.sql - we tried with ed scripts, but now we are trying with Ruby scripts, for fault tolerance.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
1. bundle exec rake db:schema:dump
2. bundle exec rake db:clean_up_structure_sql_ruby
3.  RAILS_ENV=test bin/rails db:drop db:create db:schema:load
4.  run tests


## Tests
- [x] Unit tests - well, we are testing by calling the tests...
- [ ] Manual testing

-## Related Issues
<!-- Link to related issues (if any) -->

## Pre-merge steps - Not sure if necessary - there is nothing user-visible here, we are passing this PR around to try it out
- [ ] Bumped version
- [ ] Updated changelog (Please add an entry to the changelog for the current year)
