### PR TITLE
NSL-3931: Reference search from Details tab: link to new searcy for list of novelties sorted by page

### DIFF
--- a/app/models/instance/as_array/for_reference/for_novelties.rb
+++ b/app/models/instance/as_array/for_reference/for_novelties.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+# Instances are associated with a Reference as:
+# - standalone instances for the Reference, or as
+# - relationship instances that cite or are cited by those standalones.
+#
+# This class collects the instances associated with a single reference
+# in the accepted order and sets the display attributes for each record.
+#
+# The collection is in the results attribute.
+#
+# e.g.
+# reference = [find some reference]
+# instances = Instance::AsArray::ForReference.new(reference)
+# puts instances.results.size
+#
+class Instance::AsArray::ForReference::ForNovelties < Array
+  attr_reader :results
+
+  def initialize(reference, sort_by = "name", limit = 1000, offset = 0)
+    debug("init #{reference.citation}")
+    @results = []
+    @already_shown = []
+    @reference = reference
+    @count = 0
+    @limit = limit
+    @sort_by = sort_by
+    @offset = offset || 0
+    @limit += @offset if @limit < @offset
+    find_instances
+  end
+
+  def debug(s)
+    Rails.logger.debug("Instance::AsArray::ForReference: #{s}")
+  end
+
+  def find_instances
+    debug "find_instances"
+    @reference.display_as_part_of_concept
+    @count = 1
+    find_instances_for_ref
+    @limited = true if @count > @limit
+    @results
+  end
+
+  def built_query
+    query = @reference
+            .instances
+            .joins(:name)
+            .includes(name: :name_status)
+            .joins(:instance_type)
+            .where(instance_type: { primary_instance: true })
+            .includes(this_is_cited_by: %i[name instance_type])
+    @sort_by == "page" ? query.ordered_by_page : query.ordered_by_name
+  end
+
+  def find_instances_for_ref
+    built_query.each do |instance|
+      if instance.cited_by_id.blank?
+        if @count < @offset
+          @count += 1
+        elsif @count < @limit
+          @count += 1
+          include_standalone_instance_and_synonymy(instance)
+          include_synonym(instance) unless instance.cites_this.nil?
+        end
+      end
+      break if @count > @limit
+    end
+  end
+
+  def include_standalone_instance_and_synonymy(instance)
+    instance.display_within_reference
+    @results.push(instance)
+    #instance.is_cited_by
+    #        .each do |cited_by|
+    #  @count += 1
+    #  cited_by.expanded_instance_type = cited_by.instance_type.name
+    #  @results.push(cited_by)
+    #end
+  end
+
+  def include_synonym(instance)
+    @results.push(instance.cites_this)
+    @count += 1
+  end
+end

--- a/app/models/search/on_model/base.rb
+++ b/app/models/search/on_model/base.rb
@@ -70,6 +70,7 @@ class Search::OnModel::Base
     @common_and_cultivar_included = list_query.common_and_cultivar_included
     @do_count_totals = list_query.do_count_totals
     consider_instances(parsed_request)
+    consider_novelties(parsed_request)
     consider_loader_name_extras(parsed_request)
     if @do_count_totals
       @count = @results.size
@@ -83,6 +84,12 @@ class Search::OnModel::Base
     return unless parsed_request.show_instances
 
     show_instances(parsed_request)
+  end
+
+  def consider_novelties(parsed_request)
+    return unless parsed_request.show_novelties
+
+    show_novelties(parsed_request)
   end
 
   def show_instances(parsed_request)
@@ -101,6 +108,24 @@ class Search::OnModel::Base
 
   def instances_sort_key(parsed_request)
     parsed_request.order_instances_by_page ? "page" : "name"
+  end
+
+  def show_novelties(parsed_request)
+    results_with_instances = []
+    @results.each do |ref|
+      results_with_instances << ref
+      instances_query = Instance::AsArray::ForReference::ForNovelties
+                        .new(ref,
+                             novelties_sort_key(parsed_request),
+                             parsed_request.limit,
+                             parsed_request.instance_offset)
+      instances_query.results.each { |i| results_with_instances << i }
+    end
+    @results = results_with_instances
+  end
+
+  def novelties_sort_key(parsed_request)
+    parsed_request.order_novelties_by_page ? "page" : "name"
   end
 
   def consider_loader_name_extras(parsed_request)

--- a/app/models/search/parsed_request.rb
+++ b/app/models/search/parsed_request.rb
@@ -24,6 +24,7 @@
 #   "is-orth-var-and-sec-ref-first: limit: 2" })
 class Search::ParsedRequest
   attr_reader :show_instances,
+              :show_novelties,
               :canonical_query_string,
               :common_and_cultivar,
               :count,
@@ -40,6 +41,7 @@ class Search::ParsedRequest
               :list,
               :order,
               :order_instances_by_page,
+              :order_novelties_by_page,
               :params,
               :query_string,
               :query_target,
@@ -154,6 +156,7 @@ class Search::ParsedRequest
   }.freeze
 
   ALLOW_SHOW_INSTANCES_TARGETS = %w[names name references reference]
+  ALLOW_SHOW_NOVELTIES_TARGETS = %w[references reference]
 
   TRIM_RESULTS = {
     "loader name" => true,
@@ -182,6 +185,9 @@ class Search::ParsedRequest
   }
 
   SHOW_INSTANCES = "show-instances:"
+  SHOW_INSTANCES_BY_PAGE = "show-instances-by-page:"
+  SHOW_NOVELTIES = "show-novelties:"
+  SHOW_NOVELTIES_BY_PAGE = "show-novelties-by-page:"
 
   def initialize(params)
     @params = params
@@ -231,6 +237,8 @@ class Search::ParsedRequest
     unused_qs_tokens = parse_common_and_cultivar(unused_qs_tokens)
     unused_qs_tokens = inflate_show_instances_abbrevs(unused_qs_tokens)
     unused_qs_tokens = parse_show_instances(unused_qs_tokens)
+    unused_qs_tokens = inflate_show_novelties_abbrevs(unused_qs_tokens)
+    unused_qs_tokens = parse_show_novelties(unused_qs_tokens)
     unused_qs_tokens = parse_order_instances(unused_qs_tokens)
     unused_qs_tokens = parse_view(unused_qs_tokens)
     unused_qs_tokens = parse_show_profiles(unused_qs_tokens)
@@ -542,7 +550,15 @@ class Search::ParsedRequest
   def inflate_show_instances_abbrevs(tokens)
     tokens = inflate_token(tokens, "s-i:", SHOW_INSTANCES)
     tokens = inflate_token(tokens, "si:", SHOW_INSTANCES)
-    inflate_token(tokens, "i:", SHOW_INSTANCES)
+    tokens = inflate_token(tokens, "i:", SHOW_INSTANCES)
+    inflate_token(tokens, "ibp:", SHOW_INSTANCES_BY_PAGE)
+  end
+
+  def inflate_show_novelties_abbrevs(tokens)
+    tokens = inflate_token(tokens, "s-nov:", SHOW_NOVELTIES)
+    tokens = inflate_token(tokens, "snov:", SHOW_NOVELTIES)
+    tokens = inflate_token(tokens, "nov:", SHOW_NOVELTIES)
+    inflate_token(tokens, "novbp:", SHOW_NOVELTIES_BY_PAGE)
   end
 
   def inflate_token(tokens, abbrev_s, full_s)
@@ -569,10 +585,33 @@ class Search::ParsedRequest
     tokens
   end
 
+  def parse_show_novelties(tokens)
+    if tokens.include?("show-novelties:")
+      show_novelties_allowed?
+      @show_novelties = true
+      @order_novelties_by_page = false
+      tokens.delete_if { |x| x.match(/show-novelties:/) }
+    elsif tokens.include?("show-novelties-by-page:")
+      show_novelties_allowed?
+      @show_novelties = true
+      @order_novelties_by_page = true
+      tokens.delete_if { |x| x.match(/show-novelties-by-page:/) }
+    else
+      @show_novelties = false
+    end
+    tokens
+  end
+
   def show_instances_allowed?
     return if ALLOW_SHOW_INSTANCES_TARGETS.include?(@query_target)
 
     raise "The show-instances: directive is not supported for this query"
+  end
+
+  def show_novelties_allowed?
+    return if ALLOW_SHOW_NOVELTIES_TARGETS.include?(@query_target)
+
+    raise "The show-novelties: directive is not supported for this query"
   end
 
   def parse_order_instances(tokens)

--- a/app/views/references/advanced_search/_help.html.erb
+++ b/app/views/references/advanced_search/_help.html.erb
@@ -20,5 +20,14 @@ The <code>show-instances:</code> directive also has abbreviations: <code>s-i:</c
 Add <code>instance-offset: 999</code> to offset the instances for each reference retrieved.
 <br>
 <br>
+
+<h4>Show novelties</h4>
+<p/>You can show novelties for a reference, much the same as the way to show instances.
+<p/>Add <code>show-novelties:</code> or <code>show-novelties-by-page:</code> to retrieve novelties.
+<p>
+<p>
+The <code>show-novelties:</code> directive also has abbreviations: <code>s-nov:</code>, <code>snov:</code>, and <code>nov:</code> that all do the same thing.
+<br>
+<br>
 <%= render partial: 'references/advanced_search/directives_list' %>
 

--- a/app/views/references/advanced_search/_help.html.erb
+++ b/app/views/references/advanced_search/_help.html.erb
@@ -26,8 +26,9 @@ Add <code>instance-offset: 999</code> to offset the instances for each reference
 <p/>Add <code>show-novelties:</code> or <code>show-novelties-by-page:</code> to retrieve novelties.
 <p>
 <p>
-The <code>show-novelties:</code> directive also has abbreviations: <code>s-nov:</code>, <code>snov:</code>, and <code>nov:</code> that all do the same thing.
-<br>
+The <code>show-novelties:</code> directive also has abbreviations: <code>s-nov:</code>, <code>snov:</code>,  and <code>nov:</code> that all do the same thing.
+<p>
+The <code>show-novelties-by-page:</code> directive has an abbreviation: <code>novbp:</code>.
 <br>
 <%= render partial: 'references/advanced_search/directives_list' %>
 

--- a/app/views/references/tabs/_tab_show_1.html.erb
+++ b/app/views/references/tabs/_tab_show_1.html.erb
@@ -47,44 +47,8 @@
                           title: "Retrieve this reference with its #{pluralize(duplicates.size,'duplicate')}") %>
 <% end %>
 
-<% instances_size = @reference.instances.count %>
-<% if instances_size > 0 %>
-  <br>
-  <% if instances_size == 1 %>
-    <%= link_to("1 Instance #{search_icon_on_tab}".html_safe,
-                          search_path(query_target: "references", query_string: "id: #{@reference.id} show-instances:"),
-                          tabindex: increment_tab_index,
-                          title: 'Search for the instance.') %>
-  <% else %>
-    <%= "#{instances_size} Instances" %>
-    <br>
-    <%= link_to("&mdash; sorted by name #{search_icon_on_tab}".html_safe,
-                search_path(query_string:
-                            "id: #{@reference.id} show-instances:",
-                            query_target: 'references'),
-                tabindex: increment_tab_index,
-                title: 'Search for the instances, sorted by name.',
-                class: 'instance')
-    %>
-    <br>
-    <%= link_to("&mdash; sorted by page #{search_icon_on_tab}".html_safe,
-                search_path(query_string: "id:#{@reference.id.to_s} show-instances-by-page:",
-                            query_target: "references"),
-                tabindex: increment_tab_index,
-                title: 'Search for the instances, sorted by page.',
-                class: 'instance')
-    %>
-   <% end %>
-<% end %>
-  <br>
-<% novelties = @reference.novelties %>
-<% if novelties.size > 0 %>
-  <%= link_to("#{pluralize(novelties.size,"Novelty")} #{search_icon_on_tab}".html_safe,
-                        search_path(query_target: "References with novelties", query_string: "id:#{@reference.id}"),
-                        tabindex: increment_tab_index,
-                        title: 'Taxon novelties in this reference.',
-                        class: 'instance') %>
-<% end %>
+<%= render partial: 'references/tabs/details/instances' %>
+<%= render partial: 'references/tabs/details/novelties' %>
 
 <% if @reference.products.present? %>
   <h5>Products:</h5>

--- a/app/views/references/tabs/details/_instances.html.erb
+++ b/app/views/references/tabs/details/_instances.html.erb
@@ -1,0 +1,30 @@
+
+<% instances_size = @reference.instances.count %>
+<% if instances_size > 0 %>
+  <br>
+  <% if instances_size == 1 %>
+    <%= link_to("1 Instance #{search_icon_on_tab}".html_safe,
+                          search_path(query_target: "references", query_string: "id: #{@reference.id} show-instances:"),
+                          tabindex: increment_tab_index,
+                          title: 'Search for the instance.') %>
+  <% else %>
+    <%= "#{instances_size} Instances" %>
+    <br>
+    <%= link_to("&mdash; sorted by name #{search_icon_on_tab}".html_safe,
+                search_path(query_string:
+                            "id: #{@reference.id} show-instances:",
+                            query_target: 'references'),
+                tabindex: increment_tab_index,
+                title: 'Search for the instances, sorted by name.',
+                class: 'instance')
+    %>
+    <br>
+    <%= link_to("&mdash; sorted by page #{search_icon_on_tab}".html_safe,
+                search_path(query_string: "id:#{@reference.id.to_s} show-instances-by-page:",
+                            query_target: "references"),
+                tabindex: increment_tab_index,
+                title: 'Search for the instances, sorted by page.',
+                class: 'instance')
+    %>
+   <% end %>
+<% end %>

--- a/app/views/references/tabs/details/_novelties.html.erb
+++ b/app/views/references/tabs/details/_novelties.html.erb
@@ -1,0 +1,31 @@
+
+
+<% novelties = @reference.novelties %>
+<% if novelties.size > 0 %>
+  <br>
+  <% if novelties.size == 1 %>
+    <%= link_to("1 Novelty #{search_icon_on_tab}".html_safe,
+                          search_path(query_target: "references", query_string: "id: #{@reference.id} show-novelties:"),
+                          tabindex: increment_tab_index,
+                          title: 'Search for the instance with novelty.') %>
+  <% else %>
+    <%= "#{novelties.size} Novelties" %>
+    <br>
+    <%= link_to("&mdash; sorted by name #{search_icon_on_tab}".html_safe,
+                search_path(query_string:
+                            "id: #{@reference.id} show-novelties:",
+                            query_target: 'references'),
+                tabindex: increment_tab_index,
+                title: 'Search for the novelties, sorted by name.',
+                class: 'instance')
+    %>
+    <br>
+    <%= link_to("&mdash; sorted by page #{search_icon_on_tab}".html_safe,
+                search_path(query_string: "id:#{@reference.id.to_s} show-novelties-by-page:",
+                            query_target: "references"),
+                tabindex: increment_tab_index,
+                title: 'Search for the novelties, sorted by page.',
+                class: 'instance')
+    %>
+   <% end %>
+<% end %>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 26-June-2026
+  :jira_id: '3931'
+  :description: |-
+    Reference search from Details tab: link to new searcy for list of novelties sorted by page
+- :date: 26-June-2026
   :jira_id: '5837'
   :description: |-
     Display the api_name and api_at info in the audit details for profile item details tab

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.7
+appversion=5.1.4.8

--- a/test/models/instance/as_array/for_reference/for_novelties_test.rb
+++ b/test/models/instance/as_array/for_reference/for_novelties_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# Tests for Instance::AsArray::ForReference::ForNovelties.
+class InstanceAsArrayForReferenceForNoveltiesTest < ActiveSupport::TestCase
+  test "results is an Array" do
+    ref = references(:de_fructibus_et_seminibus_plantarum)
+    result = Instance::AsArray::ForReference::ForNovelties.new(ref)
+    assert result.results.instance_of?(Array), "results should be an Array"
+  end
+
+  test "returns primary instances for a reference that has them" do
+    ref = references(:de_fructibus_et_seminibus_plantarum)
+    result = Instance::AsArray::ForReference::ForNovelties.new(ref)
+    assert result.results.any?, "Should find primary instances for this reference"
+  end
+
+  test "returns empty results for a reference with no primary instances" do
+    ref = references(:simple)
+    result = Instance::AsArray::ForReference::ForNovelties.new(ref)
+    assert result.results.empty?, "Should return no results for a reference with no instances"
+  end
+
+  test "results sorted by name by default" do
+    ref = references(:de_fructibus_et_seminibus_plantarum)
+    result = Instance::AsArray::ForReference::ForNovelties.new(ref, "name")
+    assert result.results.instance_of?(Array)
+  end
+
+  test "results sorted by page when requested" do
+    ref = references(:de_fructibus_et_seminibus_plantarum)
+    result = Instance::AsArray::ForReference::ForNovelties.new(ref, "page")
+    assert result.results.instance_of?(Array)
+  end
+end

--- a/test/models/search/on_reference/directives/show_novelties/simple_test.rb
+++ b/test/models/search/on_reference/directives/show_novelties/simple_test.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+
+# Tests for the show-novelties: search directive on references.
+class SearchOnReferenceShowNoveltiesSimpleTest < ActiveSupport::TestCase
+  def search_for(reference, query_suffix = "show-novelties:")
+    Search::Base.new(
+      ActiveSupport::HashWithIndifferentAccess.new(
+        query_target: "references",
+        query_string: "id: #{reference.id} #{query_suffix}",
+        current_user: build_edit_user
+      )
+    )
+  end
+
+  test "show-novelties: returns an array of results" do
+    ref = references(:de_fructibus_et_seminibus_plantarum)
+    search = search_for(ref)
+    assert search.executed_query.results.instance_of?(Array),
+           "show-novelties: should produce an Array of results"
+  end
+
+  test "show-novelties: interleaves primary instances after the reference" do
+    ref = references(:de_fructibus_et_seminibus_plantarum)
+    search = search_for(ref)
+    results = search.executed_query.results
+    assert results.size > 1,
+           "Results should include the reference plus at least one primary instance"
+    assert_equal Reference, results.first.class,
+                 "First result should be the reference"
+    assert_equal Instance, results[1].class,
+                 "Second result should be an instance"
+  end
+
+  test "show-novelties-by-page: returns results sorted by page" do
+    ref = references(:de_fructibus_et_seminibus_plantarum)
+    search = search_for(ref, "show-novelties-by-page:")
+    assert search.executed_query.results.instance_of?(Array),
+           "show-novelties-by-page: should produce an Array of results"
+  end
+
+  test "show-novelties: on reference with no primary instances returns only the reference" do
+    ref = references(:simple)
+    search = search_for(ref)
+    results = search.executed_query.results
+    assert_equal 1, results.size,
+                 "Should return only the reference when it has no primary instances"
+  end
+end

--- a/test/models/search/parsed_request/show_novelties_test.rb
+++ b/test/models/search/parsed_request/show_novelties_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+
+# Tests for show-novelties: parsing in Search::ParsedRequest.
+class SearchParsedRequestShowNoveltiesTest < ActiveSupport::TestCase
+  def ref_params(query_string)
+    ActiveSupport::HashWithIndifferentAccess.new(
+      query_target: "reference",
+      canonical_query_target: "references",
+      query_string: query_string,
+      include_common_and_cultivar_session: true,
+      current_user: build_edit_user
+    )
+  end
+
+  test "show-novelties: sets show_novelties true and order_novelties_by_page false" do
+    pr = Search::ParsedRequest.new(ref_params("show-novelties:"))
+    assert pr.show_novelties, "show_novelties should be true"
+    assert_not pr.order_novelties_by_page, "order_novelties_by_page should be false"
+  end
+
+  test "show-novelties-by-page: sets show_novelties true and order_novelties_by_page true" do
+    pr = Search::ParsedRequest.new(ref_params("show-novelties-by-page:"))
+    assert pr.show_novelties, "show_novelties should be true"
+    assert pr.order_novelties_by_page, "order_novelties_by_page should be true"
+  end
+
+  test "no novelties directive sets show_novelties false" do
+    pr = Search::ParsedRequest.new(ref_params(""))
+    assert_not pr.show_novelties, "show_novelties should be false when directive absent"
+  end
+
+  test "nov: abbreviation expands to show-novelties:" do
+    pr = Search::ParsedRequest.new(ref_params("nov:"))
+    assert pr.show_novelties, "nov: should expand to show-novelties:"
+    assert_not pr.order_novelties_by_page
+  end
+
+  test "snov: abbreviation expands to show-novelties:" do
+    pr = Search::ParsedRequest.new(ref_params("snov:"))
+    assert pr.show_novelties, "snov: should expand to show-novelties:"
+  end
+
+  test "s-nov: abbreviation expands to show-novelties:" do
+    pr = Search::ParsedRequest.new(ref_params("s-nov:"))
+    assert pr.show_novelties, "s-nov: should expand to show-novelties:"
+  end
+
+  test "novbp: abbreviation expands to show-novelties-by-page:" do
+    pr = Search::ParsedRequest.new(ref_params("novbp:"))
+    assert pr.show_novelties, "novbp: should expand to show-novelties-by-page:"
+    assert pr.order_novelties_by_page, "novbp: should set order_novelties_by_page true"
+  end
+
+  test "show-novelties: raises error for non-reference targets" do
+    params = ActiveSupport::HashWithIndifferentAccess.new(
+      query_target: "name",
+      canonical_query_target: "names",
+      query_string: "show-novelties:",
+      include_common_and_cultivar_session: true,
+      current_user: build_edit_user
+    )
+    assert_raises(RuntimeError) { Search::ParsedRequest.new(params) }
+  end
+end


### PR DESCRIPTION
## Description
See Jira.  Also from Claude:

This change adds a "show novelties" feature to reference search, parallel to the existing "show instances" functionality. Here's what each part does:
New model: Instance::AsArray::ForReference::ForNovelties

A new class modelled on the existing ForReference class. It queries only primary instances for a reference (i.e. novelties — names first published in that reference), with sort support by name or page.
Search::ParsedRequest

Adds show_novelties and order_novelties_by_page attributes, new query string keywords show-novelties: and show-novelties-by-page:, and abbreviations s-nov:, snov:, nov:, novbp:. The feature is restricted to references targets only (via ALLOW_SHOW_NOVELTIES_TARGETS).
Search::OnModel::Base

Adds consider_novelties and show_novelties methods that expand search results by interleaving novelty instances inline after each reference, the same way show_instances already works.
View refactoring

Extracts the instances links out of _tab_show_1.html.erb into a new _instances partial, and adds a new _novelties partial with sorted-by-name and sorted-by-page search links.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
See Jira

## Tests
- [x] Unit tests - from Claude
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
