### PR TITLE
FLOR-242 Refresh after create a version update

### DIFF
--- a/app/views/profile_items/versioned_copies/create.turbo_stream.erb
+++ b/app/views/profile_items/versioned_copies/create.turbo_stream.erb
@@ -6,10 +6,7 @@
         title: "Refresh to view the new version",
         style: "margin-left: 10px;",
         data: {
-          id: @instance.try('id'),
-          show_profiles: "",
-          focus_id: @new_profile_item.id,
-          query_target: "instance"
+          focus_id: @new_profile_item.id
         }
       )
     %>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,9 @@
 - :date: 26-June-2026
+  :jira_id: '242'
+  :jira_project: FLOR
+  :description: |-
+    Fixup the refresh button not redirecting properly after creating a versioned update of a profile item
+- :date: 26-June-2026
   :jira_id: '5802'
   :description: |-
     Search: Fix the "list" link that appears in the summary of a count query

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.11
+appversion=5.1.4.12


### PR DESCRIPTION
## Description
Fixup the refresh button not redirecting properly after creating a version update of a profile item

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
