### PR TITLE
NSL-4361: Instance Details tab for taxonomic instances: display "taxon link" only after tree version publication

### DIFF
--- a/app/views/instances/tabs/_tab_show_tree.html.erb
+++ b/app/views/instances/tabs/_tab_show_tree.html.erb
@@ -47,11 +47,14 @@
       </a>
     </dd>
 
-    <dt>Taxon link</dt>
-    <dd>
-      <a href="<%= tve.full_taxon_link %>" title="Taxon link id">
-        <i class="fa fa-sitemap"></i> ... <%= tve.taxon_link %>
-      </a>
-    </dd>
+    <% if tve.tree_version.published? %>
+      <br>
+      <dt>Taxon link</dt>
+      <dd>
+        <a href="<%= tve.full_taxon_link %>" title="Taxon link id">
+          <i class="fa fa-sitemap"></i> ... <%= tve.taxon_link %>
+        </a>
+      </dd>
+    <% end %>
   </dl>
 </div>

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 26-June-2026
+  :jira_id: '4361'
+  :description: |-
+    Instance Details tab for taxonomic instances: display "taxon link" only after tree version publication
+- :date: 26-June-2026
   :jira_id: '242'
   :jira_project: FLOR
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.12
+appversion=5.1.4.13


### PR DESCRIPTION
## Description
Small bug fix, see Jira for details.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
See Jira

## Tests
- [ ] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
