### PR TITLE
Fix entry for NSL-4523 that hid entry for NSL-4642 in the 2023 history file

### DIFF
--- a/config/history/changes-2023.yml
+++ b/config/history/changes-2023.yml
@@ -464,6 +464,7 @@
   :jira_id: '4642'
   :description: |- 
     Loader: Add rescue clauses to log_to_table methods - will avoid any unforeseen logging problems falsely reporting a transaction failed - :date: 08-Sep-2023
+- :date: 08-Sep-2023
   :jira_id: '4523'
   :description: |-
     Reference ISSN: Fix display and link


### PR DESCRIPTION
## Description
Tiny change to history file from 2023.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
Show history file for 2023 and notice entry for nsl-4620


## Tests
- [ ] Unit tests
- [x] Manual testing


## Pre-merge steps 
- [ ] Bumped version - no, I think unnecessary and needless noise for these
- [ ] Updated changelog (Please add an entry to the changelog for the current year)
