### PR TITLE
NSL-4573 - Add name tag search functionality with corresponding tests

### DIFF
--- a/app/views/names/advanced_search/_field_help.html.erb
+++ b/app/views/names/advanced_search/_field_help.html.erb
@@ -296,6 +296,27 @@
   <% end %>
 </table>
 
+<h5>Name Tag Search</h5>
+<table class="table table-striped">
+  <% [
+      {field_name: 'tag:', description: "find names that have a name tag matching the value you enter after the directive. Leading and trailing wildcards are added to your search term. With no value, finds names that have no tags"},
+      {field_name: 'has-tags:', description: "find names that have at least one name tag; no argument"},
+      {field_name: 'has-no-tags:', description: "find names that have no name tags at all; no argument"},
+      ].each do |val| %>
+  <tr>
+    <td class="width-20-percent">
+        <a href="javascript:void(0)" class="searchable-field width-100-percent"
+           data-search-directive="<%= val[:field_name] %>"
+           title='Add "<%= val[:field_name] %>" field to search.'>
+          <span class="blue"><%= val[:field_name] %></span>
+        </a>
+    </td>
+    <td><%= val[:description].html_safe %></td>
+  </tr>
+  <% end %>
+</table>
+<br>
+
 <h5>Name Status Assertion or Category Search</h5>
 <table class="table table-striped">
   <% [

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 30-June-2026
+  :jira_id: '4573'
+  :description: |-
+    Add tag:, has-tags:, and has-no-tags: directives to the Name search
+- :date: 30-June-2026
   :jira_id: '4137'
   :description: |-
     Reference Novel Names: Add Name search <code>novel-names-for-ref:</code> linked from Reference -> Details tab

--- a/config/name-searches.yml
+++ b/config/name-searches.yml
@@ -910,3 +910,18 @@ INNER JOIN name n
  WHERE instance.reference_id = ? 
    AND instance_type.primary_instance = TRUE 
   )"
+'tag:':
+  :leading_wildcard: true
+  :trailing_wildcard: true
+  :where_clause: " exists (select null
+    from name_tag_name ntn
+    join name_tag nt on nt.id = ntn.tag_id
+   where ntn.name_id = name.id
+     and lower(nt.name) like lower(?)) "
+  :not_exists_clause: " not exists (select null
+    from name_tag_name ntn
+   where ntn.name_id = name.id) "
+'has-tags:':
+  :where_clause: " exists (select null from name_tag_name ntn where ntn.name_id = name.id)"
+'has-no-tags:':
+  :where_clause: " not exists (select null from name_tag_name ntn where ntn.name_id = name.id)"

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.16
+appversion=5.1.4.17

--- a/test/fixtures/name_tag_names.yml
+++ b/test/fixtures/name_tag_names.yml
@@ -30,3 +30,10 @@
 #  fk_22wdc2pxaskytkgpdgpyok07n  (name_id => name.id)
 #  fk_2uiijd73snf6lh5s6a82yjfin  (tag_id => name_tag.id)
 #
+a_genus_acra:
+  name: a_genus
+  name_tag: acra
+  created_by: tester
+  updated_by: tester
+  created_at: <%= Time.now %>
+  updated_at: <%= Time.now %>

--- a/test/models/search/on_name/tag/simple_test.rb
+++ b/test/models/search/on_name/tag/simple_test.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+
+# Single Search model test for Name target filtered by name tag.
+class SearchOneNameTagSimpleTest < ActiveSupport::TestCase
+  test "search on name tag" do
+    params =  ActiveSupport::HashWithIndifferentAccess
+              .new(query_target: "name",
+                   query_string: "tag: acra",
+                   include_common_and_cultivar_session: true,
+                   current_user: build_edit_user)
+    search = Search::Base.new(params)
+    assert !search.executed_query.results.empty?, "Results expected."
+  end
+
+  test "search on name tag is case insensitive" do
+    params =  ActiveSupport::HashWithIndifferentAccess
+              .new(query_target: "name",
+                   query_string: "tag: ACRA",
+                   include_common_and_cultivar_session: true,
+                   current_user: build_edit_user)
+    search = Search::Base.new(params)
+    assert !search.executed_query.results.empty?, "Results expected."
+  end
+
+  test "search on name tag with no match returns nothing" do
+    params =  ActiveSupport::HashWithIndifferentAccess
+              .new(query_target: "name",
+                   query_string: "tag: no-such-tag",
+                   include_common_and_cultivar_session: true,
+                   current_user: build_edit_user)
+    search = Search::Base.new(params)
+    assert search.executed_query.results.empty?, "No results expected."
+  end
+
+  test "has-tags finds tagged names" do
+    params =  ActiveSupport::HashWithIndifferentAccess
+              .new(query_target: "name",
+                   query_string: "has-tags:",
+                   include_common_and_cultivar_session: true,
+                   current_user: build_edit_user)
+    search = Search::Base.new(params)
+    assert !search.executed_query.results.empty?, "Results expected."
+  end
+
+  test "has-no-tags finds untagged names" do
+    params =  ActiveSupport::HashWithIndifferentAccess
+              .new(query_target: "name",
+                   query_string: "has-no-tags:",
+                   include_common_and_cultivar_session: true,
+                   current_user: build_edit_user)
+    search = Search::Base.new(params)
+    assert !search.executed_query.results.empty?, "Results expected."
+  end
+
+  test "empty tag directive finds untagged names" do
+    params =  ActiveSupport::HashWithIndifferentAccess
+              .new(query_target: "name",
+                   query_string: "tag:",
+                   include_common_and_cultivar_session: true,
+                   current_user: build_edit_user)
+    search = Search::Base.new(params)
+    assert !search.executed_query.results.empty?, "Results expected."
+  end
+end


### PR DESCRIPTION
## Description
Add support for name search `tag:`, `has-tags:`, and `has-no-tags:` directives

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
