### PR TITLE
NSL-4984: Names plus instances search: Retain the correct query target when reporting an error

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -88,6 +88,7 @@ class SearchController < ApplicationController
 
   def run_empty_search_to_show_error(params)
     @empty_search = true
+    params[:query_target] = params[:original_query_target]
     @search = Search::Empty.new(params)
   end
 
@@ -116,6 +117,7 @@ class SearchController < ApplicationController
     return unless params[:query_target].present?
     return unless params[:query_target] =~ /Names plus instances/i
 
+    params[:original_query_target] = params[:query_target]
     params[:query_target] = "name"
     return if params[:query_string] =~ /show-instances:/
 

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,4 +1,8 @@
 - :date: 30-June-2026
+  :jira_id: '4984'
+  :description: |-
+    Names plus instances search: Retain the correct query target when reporting an error
+- :date: 30-June-2026
   :jira_id: '5818'
   :description: |-
     Name Editing: improve notification when a name author has no abbreviation 

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.18
+appversion=5.1.4.19

--- a/test/controllers/search/names_plus_instances/error_preserves_query_target_test.rb
+++ b/test/controllers/search/names_plus_instances/error_preserves_query_target_test.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+
+require "test_helper"
+
+# When a "Names plus instances" search raises a StandardError, the controller
+# rewrites query_target to "name" before the error occurs.  The fix saves the
+# original value in params[:original_query_target] and restores it inside
+# run_empty_search_to_show_error, so the error page is rendered with the
+# correct query target rather than the internal "name" rewrite.
+#
+# The show-novelties: directive raises a RuntimeError (StandardError subclass)
+# for the "name" target (only allowed for "references"), giving us a reliable
+# way to exercise the error path without a database error.
+class NamesSearchControllerNamesAndInstancesErrorPreservesQueryTargetTest < ActionController::TestCase
+  tests SearchController
+
+  test "error during Names plus instances search preserves original query target in rendered form" do
+    get(:search,
+        params: { query_target: "Names plus instances",
+                  query_string: "angophora show-novelties:" },
+        session: { username: "fred",
+                   user_full_name: "Fred Jones",
+                   groups: [] })
+    assert_response :success
+    assert_select "input#query-target[value=?]", "Names plus instances"
+  end
+end


### PR DESCRIPTION


## Description
From Claude: 

The uncommitted change is a two-line bugfix in app/controllers/search_controller.rb.

When a user searches with the "Names plus instances" query target, the controller rewrites query_target to "name" before running the search. 

If the search fails and falls through to run_empty_search_to_show_error, the original target had already been overwritten — so the error display would incorrectly reflect "name" rather than "Names plus instances".

The fix saves the original target in params[:original_query_target] before overwriting it, then restores it inside run_empty_search_to_show_error so the error state is presented with the correct query target.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How to Test
Described in Jira

## Tests
- [x] Unit tests - got Claude to write minitest
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
