### PR TITLE
NSL-5402: Instance Search: Add is-standalone: and is-not-standalone: directives

### DIFF
--- a/app/models/search/on_instance/field_rule.rb
+++ b/app/models/search/on_instance/field_rule.rb
@@ -225,6 +225,16 @@ from comment where comment.instance_id = instance.id)",
                        where instance_type_id = instance_type.id
                        and instance_type.primary_instance) ",
                        takes_no_arg: true},
+    "is-standalone:" => { where_clause: " exists (select null
+                                          from instance_type
+                                          where instance_type_id = instance_type.id
+                                          and instance_type.standalone) ",
+                         },
+    "is-not-standalone:" => { where_clause: " exists (select null
+                                          from instance_type
+                                          where instance_type_id = instance_type.id
+                                          and not instance_type.standalone) ",
+                         },
     "is-tax-nov-for-orth-var-name:" => { where_clause: " exists (select null
                                  from instance_type
                                  where instance_type_id = instance_type.id

--- a/app/views/instances/advanced_search/_field_help.html.erb
+++ b/app/views/instances/advanced_search/_field_help.html.erb
@@ -260,6 +260,8 @@ word "darwin" followed by a space, one or more other characters followed by "bar
          {field_name: 'does-not-cite-an-instance:', description: ""},
          {field_name: 'is-not-cited-by-an-instance:', description: ""},
          {field_name: 'is-novelty:', description: "Primary instance type e.g. tax. nov.."},
+         {field_name: 'is-standalone:', description: "Instance type is standalone"},
+         {field_name: 'is-not-standalone:', description: "Instance type is not standalone"},
          {field_name: 'is-tax-nov-for-orth-var-name:', description: "Instance is a tax. nov. type but the name is an orth. var."},
          {field_name: 'species-or-below-syn-with-genus-or-above:',
           description: "Instance synonymises a name ranked species or below with a name that is genus or above."},

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 01-July-2026
+  :jira_id: '5402'
+  :description: |-
+    Instance Search: Add <code>is-standalone:</code> and <code>is-not-standalone:</code> directives
 - :date: 30-June-2026
   :jira_id: '4984'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.19
+appversion=5.1.4.20

--- a/test/models/search/on_instance/assertions/standalone/is_not_test.rb
+++ b/test/models/search/on_instance/assertions/standalone/is_not_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+
+# Test search on instance using the is-not-standalone: directive.
+# Fixtures with non-standalone instance types (e.g. basionym, nomenclatural_synonym)
+# should be returned.
+class SearchOnInstanceIsNotStandaloneTest < ActiveSupport::TestCase
+  test "is-not-standalone: returns instances with a non-standalone instance type" do
+    search = Search::Base.new(
+      ActiveSupport::HashWithIndifferentAccess.new(
+        query_target: "instance",
+        query_string: "is-not-standalone:",
+        current_user: build_edit_user
+      )
+    )
+    assert !search.executed_query.results.empty?,
+           "Expected results for is-not-standalone: — fixtures include basionym and nomenclatural_synonym instances"
+  end
+end

--- a/test/models/search/on_instance/assertions/standalone/is_test.rb
+++ b/test/models/search/on_instance/assertions/standalone/is_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+load "test/models/search/users.rb"
+
+# Test search on instance using the is-standalone: directive.
+# Fixtures with standalone instance types (e.g. comb_nov, secondary_reference)
+# should be returned.
+class SearchOnInstanceIsStandaloneTest < ActiveSupport::TestCase
+  test "is-standalone: returns instances with a standalone instance type" do
+    search = Search::Base.new(
+      ActiveSupport::HashWithIndifferentAccess.new(
+        query_target: "instance",
+        query_string: "is-standalone:",
+        current_user: build_edit_user
+      )
+    )
+    assert !search.executed_query.results.empty?,
+           "Expected results for is-standalone: — fixtures include comb_nov and secondary_reference instances"
+  end
+end


### PR DESCRIPTION
## Description
Summary of the change: adds two instance search directives to Search::OnInstance::FieldRule — is-standalone: and is-not-standalone: — each using an EXISTS subquery against instance_type on the standalone boolean column. Help text and changelog were updated to match.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How to Test
See Jira

## Tests
- [x] Unit tests - from Claude
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
