### PR TITLE
NSL-5846:  Tree Version Draft Creation: Fix error handling code so error messages show clearly to users

### DIFF
--- a/app/controllers/tree_versions_controller.rb
+++ b/app/controllers/tree_versions_controller.rb
@@ -122,10 +122,10 @@ class TreeVersionsController < ApplicationController
       @working_draft = nil
       render "publish"
     else
-      @message = json_result(response)
+      @message = json&.error || 'Unknown error trying to publish tree'
       render "publish_error"
     end
-  rescue Unauthorized, RestClient::Unauthorized, RestClient::Forbidden => e
+  rescue ::Unauthorized, ::RestClient::Unauthorized, ::RestClient::Forbidden => e
     @message = json_error(e)
     render "publish_error", status: :forbidden
   rescue RestClient::ExceptionWithResponse => e

--- a/config/history/changes-2026.yml
+++ b/config/history/changes-2026.yml
@@ -1,3 +1,7 @@
+- :date: 02-July-2026
+  :jira_id: '5846'
+  :description: |-
+    Tree Version Draft Creation: Fix error handling code so error messages show clearly to users
 - :date: 01-July-2026
   :jira_id: '5402'
   :description: |-

--- a/config/version.properties
+++ b/config/version.properties
@@ -1,1 +1,1 @@
-appversion=5.1.4.20
+appversion=5.1.4.21

--- a/test/integration/taxonomy/forms/tree_publisher/apc/publish_error_falls_back_to_default_message_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/publish_error_falls_back_to_default_message_test.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# When the publish service returns a non-ok response with no "error" field,
+# the controller should fall back to the default message rather than
+# calling the undefined json_result method or rendering nothing useful.
+class TaxFormsTreePubAPCPublishErrorFallsBackToDefaultMessageTest < ActionController::TestCase
+  tests TreeVersionsController
+
+  def setup
+    stub_request(:put, /http:..localhost:90...nsl.services.api.treeVersion.publish.apiKey=test-api-key.as=apc-tax-publisher/).
+      to_return(status: 200,
+                body: '{"ok":false}',
+                headers: { "Content-Type" => "application/json" })
+  end
+
+  test "publish failure with no error field renders the fallback message" do
+    user = users(:apc_tax_publisher)
+    apc_draft = tree_versions(:apc_draft_version)
+    post(:publish,
+         params: { "version_id" => apc_draft.id,
+                   "next_draft_name" => "next draft",
+                   "draft_log" => "log entry" },
+         format: :js,
+         xhr: true,
+         session: { username: user.user_name,
+                    user_full_name: user.full_name,
+                    groups: ["login"],
+                    draft: apc_draft })
+    assert_response :success
+    assert_match "Unknown error trying to publish tree", response.body
+  end
+end

--- a/test/integration/taxonomy/forms/tree_publisher/apc/publish_error_renders_json_error_field_test.rb
+++ b/test/integration/taxonomy/forms/tree_publisher/apc/publish_error_renders_json_error_field_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+#   Copyright 2015 Australian National Botanic Gardens
+#
+#   This file is part of the NSL Editor.
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+#
+require "test_helper"
+
+# When the publish service returns a non-ok response that includes an
+# "error" field, the controller should use that field as @message rather
+# than calling the undefined json_result method (which was the pre-fix
+# behaviour and caused a NoMethodError).
+class TaxFormsTreePubAPCPublishErrorRendersJsonErrorFieldTest < ActionController::TestCase
+  tests TreeVersionsController
+
+  def setup
+    stub_request(:put, /http:..localhost:90...nsl.services.api.treeVersion.publish.apiKey=test-api-key.as=apc-tax-publisher/).
+      to_return(status: 200,
+                body: '{"ok":false,"error":"Publishing service unavailable"}',
+                headers: { "Content-Type" => "application/json" })
+  end
+
+  test "publish failure renders the error field from the JSON response" do
+    user = users(:apc_tax_publisher)
+    apc_draft = tree_versions(:apc_draft_version)
+    post(:publish,
+         params: { "version_id" => apc_draft.id,
+                   "next_draft_name" => "next draft",
+                   "draft_log" => "log entry" },
+         format: :js,
+         xhr: true,
+         session: { username: user.user_name,
+                    user_full_name: user.full_name,
+                    groups: ["login"],
+                    draft: apc_draft })
+    assert_response :success
+    assert_match "Publishing service unavailable", response.body
+  end
+end


### PR DESCRIPTION
## Description
Two distinct fixes in the publish action of TreeVersionsController:
1. Broken error message on publish failure
The old code called json_result(response) in the failure branch, but json_result is defined on TreesController, not TreeVersionsController. This would raise a NoMethodError at that exact moment — meaning a publish failure would immediately fall through to the rescue => e catch-all and render a confusing stack-trace message instead of anything meaningful.
The fix replaces it with json&.error || 'Unknown error trying to publish tree', which correctly reads the error field from the already-parsed JSON response (the local variable json is set two lines above). The fallback string handles the case where the response body has no error field.
2. Unqualified constant names in rescue clause
The old rescue Unauthorized, RestClient::Unauthorized, RestClient::Forbidden looked up Unauthorized and RestClient relative to the current module nesting. If there were ever a TreeVersionsController::Unauthorized or an enclosing module defining those names, they'd shadow the intended classes silently. Adding :: anchors all three to the top-level namespace, which is where they actually live, and makes the intent unambiguous.
Both are solid fixes. The json_result bug is the more serious one — any publish failure would have immediately errored again in the error-handling branch itself.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How to Test
See Jira

## Tests
- [x] Unit tests
- [x] Manual testing

## Pre-merge steps
- [x] Bumped version
- [x] Updated changelog (Please add an entry to the changelog for the current year)
